### PR TITLE
Upgrade node + bot optimization

### DIFF
--- a/bots/test/commands.ts
+++ b/bots/test/commands.ts
@@ -93,6 +93,7 @@ export class CommandHandler {
       const conversation = await client.conversations.getConversationById(
         message.conversationId,
       );
+      console.log("conversation", conversation?.id);
       const inboxState = await client.preferences.inboxStateFromInboxIds([
         message.senderInboxId,
       ]);
@@ -100,8 +101,11 @@ export class CommandHandler {
         .filter((i) => i.identifierKind === IdentifierKind.Ethereum)
         .map((i) => i.identifier);
 
+      console.log("addresses", addresses[0]);
       await conversation?.send(addresses[0]);
+      console.log("inboxState", inboxState[0]);
       await conversation?.send(inboxState[0].inboxId);
+      console.log("installations", inboxState[0].installations[0].id);
       await conversation?.send(inboxState[0].installations[0].id);
     } catch (error) {
       console.error("Error sending me:", error);

--- a/bots/test/index.ts
+++ b/bots/test/index.ts
@@ -1,7 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { checkGroupInWebClient } from "@helpers/playwright";
 import {
-  IdentifierKind,
   type Client,
   type Conversation,
   type DecodedMessage,
@@ -13,15 +12,6 @@ import { CommandHandler } from "./commands";
 
 const testName = "test-bot";
 loadEnv(testName);
-process.on("uncaughtException", (error) => {
-  console.error("Uncaught exception:", error);
-  process.exit(1);
-});
-
-process.on("unhandledRejection", (reason, promise) => {
-  console.error("Unhandled rejection at:", promise, "reason:", reason);
-  process.exit(1);
-});
 
 async function main() {
   try {
@@ -31,7 +21,7 @@ async function main() {
     // Then create the dynamic workers
     console.log("Initializing worker workers...");
     const workers = await getWorkers(20, testName, "message", true);
-    const botWorker = await getWorkers(["bot"], testName, "none", false);
+    const botWorker = await getWorkers(["bot"], testName, "message", false);
     const bot = botWorker.get("bot");
     const client = bot?.client as Client;
 
@@ -42,7 +32,7 @@ async function main() {
     console.log("Syncing conversations...");
     await client.conversations.sync();
 
-    //await sendInitialTestMessage(client);
+    await sendInitialTestMessage(client);
     console.log("Waiting for messages...");
     try {
       const stream = client.conversations.streamAllMessages();
@@ -103,6 +93,7 @@ async function sendInitialTestMessage(client: Client) {
     throw new Error("CB_USER is not set");
   }
   const dm = await client.conversations.newDm(cbUser);
+
   await dm.send("gm from bot");
   console.log("DM sent:", dm.id);
 }
@@ -132,7 +123,8 @@ async function processCommand(
     const parts = trimmedContent.substring(1).split(" ");
     const command = parts[0].toLowerCase();
     const args = parts.slice(1);
-
+    console.log("Command:", command);
+    console.log("Args:", args);
     // Execute the appropriate command handler
     switch (command) {
       case "help":

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@hyperbrowser/sdk": "^0.29.0",
-    "@xmtp/node-sdk": "1.0.0",
+    "@xmtp/node-sdk": "1.0.4",
     "axios": "^1.8.2",
     "dotenv": "^16.4.7",
     "openai": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,13 +1328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-group-updated@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@xmtp/content-type-group-updated@npm:2.0.0"
+"@xmtp/content-type-group-updated@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@xmtp/content-type-group-updated@npm:2.0.1"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/proto": "npm:^3.72.0"
-  checksum: 10/49f4d4203932ecde56f68acf02379a1db597e2b18a42196d97cb65bfcf7b1492cc1e6feb287b1d4b092e72e79a3ea667c0358271f2a2d76288c4f4fbe179bde3
+    "@xmtp/content-type-primitives": "npm:^2.0.1"
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/75d8f30fedf2524335745865c286ef4b240e2c2c9b981d9044ef4d6b09f5c5324f13b448ef8358c4a13d3d0c49fd6a964dab6d94974cf2fcc887ecaefb2e6671
   languageName: node
   linkType: hard
 
@@ -1347,12 +1347,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-primitives@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@xmtp/content-type-primitives@npm:2.0.0"
+"@xmtp/content-type-primitives@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@xmtp/content-type-primitives@npm:2.0.1"
   dependencies:
-    "@xmtp/proto": "npm:^3.72.0"
-  checksum: 10/a5aca63b6d9cb505b78ed518f48331236bac54bb2dcae3e037b8b43d802d9e64b1da151111b5c82b1bb78a0b6c3507c0f8bfad5ffb281c77ace21430c8716b8e
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/966d17a2ef9b70452348651e7eb56d858608d4b910343bdc8886bc73693040ea34ce69bac74bd4367404f6cf6f7b6ec7b25a2dd25c507fc35bee1447065ea02d
   languageName: node
   linkType: hard
 
@@ -1365,12 +1365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/content-type-text@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@xmtp/content-type-text@npm:2.0.0"
+"@xmtp/content-type-text@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@xmtp/content-type-text@npm:2.0.1"
   dependencies:
-    "@xmtp/content-type-primitives": "npm:^2.0.0"
-  checksum: 10/8d1291983d9a52fb2465f65f4e03926cd3f30ab7d0801a8e42891e3491468415104144fe0188f6c872aefc37733d7a268072ace2a7fa65bedc98eae2bb4e60c1
+    "@xmtp/content-type-primitives": "npm:^2.0.1"
+  checksum: 10/7febd12cfbb69a80c434caef4111ccd02d5e9b24eb58fb0f27a35d5f14c61c47e949322b1715a25918ff4d70d0392116ac310a4e2e59f1e23dc2223ca8a141fc
   languageName: node
   linkType: hard
 
@@ -1393,27 +1393,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@xmtp/node-bindings@npm:1.0.0"
-  checksum: 10/8bf91003ea3859f1c535f871013d13eb1096728f51e3c81471eb5ad9a27de65a19a9817eb8efbd56e257c07076af94771845643211764ff028103e202779f6ce
+"@xmtp/node-bindings@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "@xmtp/node-bindings@npm:1.1.3"
+  checksum: 10/729473bbb36fcc0da5a700aad65e2ef2441639591ae091a35c605d1294dfac7c7201b0504706d78bc8cabcd7f6473245ed0018c65e92d78e8eaf3b741b87c6fd
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@xmtp/node-sdk@npm:1.0.0"
+"@xmtp/node-sdk@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@xmtp/node-sdk@npm:1.0.4"
   dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.0"
-    "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/content-type-text": "npm:^2.0.0"
-    "@xmtp/node-bindings": "npm:^1.0.0"
-    "@xmtp/proto": "npm:^3.72.3"
-  checksum: 10/9c07530f121304125ace483cb7db361fed43fb6f02136956d553fed669824f84d4b17499428eb0cc8849b6900bd448222c56d1fb76f454db734a4dfe8a56ea26
+    "@xmtp/content-type-group-updated": "npm:^2.0.1"
+    "@xmtp/content-type-primitives": "npm:^2.0.1"
+    "@xmtp/content-type-text": "npm:^2.0.1"
+    "@xmtp/node-bindings": "npm:^1.1.2"
+    "@xmtp/proto": "npm:^3.78.0"
+  checksum: 10/25200c64effc4d46f1e8fcdedb06b21aa2dd82b1826cf04a3b1ed9de5774421c3c444c4b56392f6ef0f96e1c1d09c4351676e353e45f385d6157253d6af637d8
   languageName: node
   linkType: hard
 
-"@xmtp/proto@npm:^3.62.1, @xmtp/proto@npm:^3.72.0, @xmtp/proto@npm:^3.72.3":
+"@xmtp/proto@npm:^3.62.1, @xmtp/proto@npm:^3.72.0, @xmtp/proto@npm:^3.78.0":
   version: 3.78.0
   resolution: "@xmtp/proto@npm:3.78.0"
   dependencies:
@@ -5237,7 +5237,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:3.0.6"
     "@vitest/ui": "npm:^3.0.6"
     "@xmtp/mls-client": "npm:0.0.13"
-    "@xmtp/node-sdk": "npm:1.0.0"
+    "@xmtp/node-sdk": "npm:1.0.4"
     axios: "npm:^1.8.2"
     datadog-metrics: "npm:^0.12.1"
     dotenv: "npm:^16.4.7"


### PR DESCRIPTION
### Move stress test worker management to module level and add manual termination via `/stress reset` command to improve worker lifecycle control
* Refactors stress test worker management in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/110/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f) by moving `workers` to module scope and implementing manual cleanup through `/stress reset` command
* Updates test bot configuration in [bots/test/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/110/files#diff-56b2bd934331e60f4cc67e32247f8091e04d66b14faa23ebb483b73f38af19cc) to enable message mode and initial message sending
* Adds debug logging in [bots/test/commands.ts](https://github.com/xmtp/xmtp-qa-testing/pull/110/files#diff-9d850759d826ec03cb7d8f45698669d9464509fe8e30a9ef5af07d72f3a5f4e2) for conversation ID, Ethereum address, inbox ID and installation ID
* Updates `@xmtp/node-sdk` from v1.0.0 to v1.0.4

#### 📍Where to Start
Start with the worker management changes in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/110/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f) where the `workers` variable has been moved to module scope and the cleanup logic has been relocated to the `/stress reset` command handler.

----

_[Macroscope](https://app.macroscope.com) summarized 3c7508a._