### PR TITLE
bump version to 0.0.10 for release readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-testing",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
### Increment package version from `0.0.9` to `0.0.10` for release readiness
Updates the version number in [package.json](https://github.com/xmtp/xmtp-qa-testing/pull/128/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) as part of standard version control for release tracking.

#### 📍Where to Start
Review the version update in [package.json](https://github.com/xmtp/xmtp-qa-testing/pull/128/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), which contains the only change in this pull request.

----

_[Macroscope](https://app.macroscope.com) summarized cc3e6af._