### PR TITLE
Refactor bot commands for clarity and usability improvements

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -8,7 +8,7 @@ This is a simple bot that replies `gm` to any message.
 
 ```bash
 # Launch test environment
-yarn bot:gm
+yarn bot gm
 ```
 
 See more in [gm/README.md](./gm/README.md)

--- a/bots/stress/README.md
+++ b/bots/stress/README.md
@@ -6,6 +6,19 @@ A lightweight toolkit for app developers to test messaging functionality against
 
 - Node.js (20.18.0)
 - Yarn
+- Random generated inboxes
+
+#### Using existing inboxes in local environment
+
+By defalt generated-inboxes.json is used to run the stress test with random generated inboxes. But they are not valid for your `local` environment.
+
+If you're developing in a `local` XMTP network, you need to re-initialize the inboxes from `generated-inboxes.json` in your local environment:
+
+```bash
+yarn script local-update
+```
+
+This will create the necessary database files in `logs/db-generated-{count}-local` and set up all inboxes to work in your local environment.
 
 ## 🔧 Installation
 
@@ -13,6 +26,7 @@ A lightweight toolkit for app developers to test messaging functionality against
 git clone https://github.com/xmtp/xmtp-qa-testing
 cd xmtp-qa-testing
 yarn install
+
 # generate random inboxes
 yarn script generate
 

--- a/bots/stress/README.md
+++ b/bots/stress/README.md
@@ -13,9 +13,11 @@ A lightweight toolkit for app developers to test messaging functionality against
 git clone https://github.com/xmtp/xmtp-qa-testing
 cd xmtp-qa-testing
 yarn install
+# generate random inboxes
+yarn script generate
 
 # Run the bot
-yarn bot:stress
+yarn bot stress
 ```
 
 ## 💬 Available Commands

--- a/bots/stress/README.md
+++ b/bots/stress/README.md
@@ -12,13 +12,14 @@ A lightweight toolkit for app developers to test messaging functionality against
 
 By defalt [generated-inboxes.json](../../helpers/generated-inboxes.json) is used to run the stress test with random generated inboxes. But they are not valid for your `local` environment.
 
-If you're developing in a `local` XMTP network, you need to re-initialize the inboxes first:
+> [!IMPORTANT]
+> If you're developing in a `local` XMTP network, you need to re-initialize the inboxes first:
 
 ```bash
 yarn script local-update
 ```
 
-This will make the current import of `generated-inboxes.json` invalid for your `local` environment.
+This will make the current import of `generated-inboxes.json` valid for your `local` environment.
 
 ```typescript
 import generatedInboxes from "@helpers/generated-inboxes.json";

--- a/bots/stress/README.md
+++ b/bots/stress/README.md
@@ -10,15 +10,19 @@ A lightweight toolkit for app developers to test messaging functionality against
 
 #### Using existing inboxes in local environment
 
-By defalt generated-inboxes.json is used to run the stress test with random generated inboxes. But they are not valid for your `local` environment.
+By defalt [generated-inboxes.json](../../helpers/generated-inboxes.json) is used to run the stress test with random generated inboxes. But they are not valid for your `local` environment.
 
-If you're developing in a `local` XMTP network, you need to re-initialize the inboxes from `generated-inboxes.json` in your local environment:
+If you're developing in a `local` XMTP network, you need to re-initialize the inboxes first:
 
 ```bash
 yarn script local-update
 ```
 
-This will create the necessary database files in `logs/db-generated-{count}-local` and set up all inboxes to work in your local environment.
+This will make the current import of `generated-inboxes.json` invalid for your `local` environment.
+
+```typescript
+import generatedInboxes from "@helpers/generated-inboxes.json";
+```
 
 ## 🔧 Installation
 

--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -14,6 +14,11 @@ loadEnv(testName);
 
 // Constants
 const HELP_TEXT = `🤖 XMTP Stress Test Bot
+
+If working on a local environment, make sure to update the generated inboxes first:
+
+yarn script local-update
+
 Available Commands:
 /help - Show this help message
 /stress <workers> <messages> - Start a stress test

--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -14,15 +14,6 @@ loadEnv(testName);
 
 // Constants
 const HELP_TEXT = `🤖 XMTP Stress Test Bot
-
-1. Set up generated inboxes with the generate script and then run the stress test.
-
-yarn script generate
-
-2. Run the stress test.
-
-yarn stress
-
 Available Commands:
 /help - Show this help message
 /stress <workers> <messages> - Start a stress test

--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -15,6 +15,14 @@ loadEnv(testName);
 // Constants
 const HELP_TEXT = `🤖 XMTP Stress Test Bot
 
+1. Set up generated inboxes with the generate script and then run the stress test.
+
+yarn script generate
+
+2. Run the stress test.
+
+yarn stress
+
 Available Commands:
 /help - Show this help message
 /stress <workers> <messages> - Start a stress test
@@ -22,10 +30,7 @@ Available Commands:
 
 Examples:
 /stress 5 10 - Create test with 5 workers sending 10 messages each
-/stress reset - Terminate all workers and start over
-
-Limits:
-- Workers: 1-40`;
+/stress reset - Terminate all workers and start over`;
 
 let isStressTestRunning = false;
 let workers: WorkerManager | undefined;
@@ -146,7 +151,7 @@ async function createLargeGroup(
   try {
     // console.log([...inboxes, client.inboxId, message.senderInboxId]);
     const group = await client.conversations.newGroup(
-      [...inboxes, client.inboxId, ...workerInboxes, message.senderInboxId],
+      [...inboxes, ...workerInboxes, message.senderInboxId],
       {
         groupName: `Large Group ${memberCount} - ${Date.now()}`,
         groupDescription: `Large group with ${memberCount} members for stress testing`,
@@ -207,7 +212,7 @@ async function runStressTest(
     // Create group
     await conversation.send("⏳ Creating test group...");
     const group = await client.conversations.newGroup(
-      [...workerInboxIds, message.senderInboxId, client.inboxId],
+      [...workerInboxIds, message.senderInboxId],
       {
         groupName: `Stress Test Group ${Date.now()}`,
         groupDescription: "Group for stress testing",

--- a/bots/test/commands.ts
+++ b/bots/test/commands.ts
@@ -159,11 +159,7 @@ export class CommandHandler {
       // Create the group name
 
       // Make sure the bot and sender are included in the group
-      const memberInboxIds = [
-        ...workerInboxIds,
-        message.senderInboxId,
-        client.inboxId,
-      ];
+      const memberInboxIds = [...workerInboxIds, message.senderInboxId];
       // Create the group
       const groupName = `testBotGroup-${Math.random().toString(36).substring(2, 15)}`;
       const group = await client.conversations.newGroup(memberInboxIds, {

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -8,6 +8,7 @@ import {
 import { Client, type XmtpEnv } from "@helpers/types";
 
 const BASE_LOGPATH = "./logs";
+const DB_PATH = "/db";
 // Define valid XMTP environments
 const validEnvironments = ["local", "dev", "production"] as XmtpEnv[];
 
@@ -119,9 +120,11 @@ async function main() {
   // Create a custom folder name based on count and environments
   const folderName = `db-generated-${numAccounts}-${environments.join(",")}`;
   const LOGPATH = `${BASE_LOGPATH}/${folderName}`;
-
-  verifyStorage(LOGPATH);
-
+  // Create db directory if it doesn't exist
+  if (!fs.existsSync(`${LOGPATH}${DB_PATH}`)) {
+    console.log(`Creating directory: ${LOGPATH}...`);
+    fs.mkdirSync(`${LOGPATH}${DB_PATH}`, { recursive: true });
+  }
   // Array to store account data
   const accountData = [];
 
@@ -151,7 +154,7 @@ async function main() {
 
       for (const env of environments) {
         const client = await Client.create(signer, encryptionKey, {
-          dbPath: `${LOGPATH}/${env}-${address}`,
+          dbPath: `${LOGPATH}${DB_PATH}/${env}-${address}`,
           env: env,
         });
 
@@ -189,11 +192,3 @@ async function main() {
 }
 
 main().catch(console.error);
-
-function verifyStorage(logPath: string) {
-  // Create db directory if it doesn't exist
-  if (!fs.existsSync(logPath)) {
-    console.log(`Creating directory: ${logPath}...`);
-    fs.mkdirSync(logPath, { recursive: true });
-  }
-}

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,20 +1,137 @@
 import * as fs from "fs";
+import * as readline from "readline";
 import {
   createSigner,
   generateEncryptionKeyHex,
   getEncryptionKeyFromHex,
 } from "@helpers/client";
-import { Client } from "@helpers/types";
+import { Client, type XmtpEnv } from "@helpers/types";
+
+const BASE_LOGPATH = "./logs";
+// Define valid XMTP environments
+const validEnvironments = ["local", "dev", "production"] as XmtpEnv[];
+
+// Function to display help
+function showHelp() {
+  console.log(`
+XMTP Account Generator
+
+Usage:
+  yarn generate 
+
+Arguments:
+  count         Number of accounts to generate (default: prompted)
+  environments  Comma-separated list of XMTP environments (local,dev,production)
+
+This will generate folder inside /logs/db-generated-{count}-{environments} folder with the name of the number of accounts and the environments.
+`);
+}
+
+// Function to create a readline interface for user input
+function createInterface() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+// Function to ask for number of accounts to generate
+async function askForAccountCount(): Promise<number> {
+  const rl = createInterface();
+
+  return new Promise((resolve) => {
+    rl.question(`How many accounts would you like to generate? `, (answer) => {
+      rl.close();
+      const count = parseInt(answer, 10);
+      if (isNaN(count) || count <= 0) {
+        console.log("Invalid input. Please enter a positive number.");
+        // Properly handle the Promise chain using void
+        void askForAccountCount().then(resolve);
+      } else {
+        resolve(count);
+      }
+    });
+  });
+}
+
+// Function to ask for environments
+async function askForEnvironments(): Promise<XmtpEnv[]> {
+  const rl = createInterface();
+
+  return new Promise((resolve) => {
+    rl.question(
+      `Enter XMTP environments to use (comma-separated: local,dev,production): `,
+      (answer) => {
+        rl.close();
+        const envs = answer.split(",").map((e) => e.trim().toLowerCase());
+        const validEnvs = envs.filter((env) =>
+          validEnvironments.includes(env as XmtpEnv),
+        );
+
+        if (validEnvs.length === 0) {
+          console.log(
+            "No valid environments provided. Using 'local' as default.",
+          );
+          resolve(["local"]);
+        } else {
+          resolve(validEnvs as XmtpEnv[]);
+        }
+      },
+    );
+  });
+}
 
 async function main() {
-  // Get number of accounts from command line arguments
+  // Get command line arguments
   const args = process.argv.slice(2);
-  const numAccounts = args.length > 0 ? parseInt(args[0], 10) : 800; // Default to 800 if no argument provided
+
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showHelp();
+    return;
+  }
+
+  // Get number of accounts
+  let numAccounts: number;
+  if (args.length > 0 && !isNaN(parseInt(args[0], 10))) {
+    numAccounts = parseInt(args[0], 10);
+  } else {
+    numAccounts = await askForAccountCount();
+  }
+
+  // Get environments
+  let environments: XmtpEnv[] = [];
+
+  if (args.length > 1) {
+    const inputEnvs = args[1].split(",").map((e) => e.trim().toLowerCase());
+    environments = inputEnvs.filter((env) =>
+      validEnvironments.includes(env as XmtpEnv),
+    ) as XmtpEnv[];
+  }
+
+  // If no valid environments specified in args, ask for them
+  if (environments.length === 0) {
+    environments = await askForEnvironments();
+  }
+
+  console.log(`Using environments: ${environments.join(", ")}`);
+
+  // Create a custom folder name based on count and environments
+  const folderName = `db-generated-${numAccounts}-${environments.join(",")}`;
+  const LOGPATH = `${BASE_LOGPATH}/${folderName}`;
+
+  verifyStorage(LOGPATH);
 
   // Array to store account data
   const accountData = [];
 
-  console.log(`Generating ${numAccounts} accounts with XMTP clients...`);
+  console.log(
+    `Generating ${numAccounts} accounts with XMTP clients for environments: ${environments.join(", ")}...`,
+  );
+
+  // Create a timestamp for the output file
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputFile = `${LOGPATH}/generated-inboxes-${timestamp}.json`;
 
   for (let i = 0; i < numAccounts; i++) {
     // Generate a random private key
@@ -28,35 +145,37 @@ async function main() {
       // Generate encryption key
       const encryptionKeyHex = generateEncryptionKeyHex();
       const encryptionKey = getEncryptionKeyFromHex(encryptionKeyHex);
-      // Create an XMTP client using the signer
-      const client = await Client.create(signer, encryptionKey, {
-        dbPath: `./scripts/db/dev-${address}`,
-        env: "dev",
-      });
-      await Client.create(signer, encryptionKey, {
-        dbPath: `./scripts/db/production-${address}`,
-        env: "production",
-      });
-      await Client.create(signer, encryptionKey, {
-        dbPath: `./scripts/db/local-${address}`,
-        env: "local",
-      });
-      // Get the inbox ID for this client
-      const inboxId = client.inboxId;
-      // Store the account address and inbox ID
+
+      // Create XMTP clients for each environment
+      const clientsInfo = [];
+
+      for (const env of environments) {
+        const client = await Client.create(signer, encryptionKey, {
+          dbPath: `${LOGPATH}/${env}-${address}`,
+          env: env,
+        });
+
+        // Get the inbox ID for this client
+        clientsInfo.push({
+          env,
+          inboxId: client.inboxId,
+        });
+
+        console.log(
+          `Created client in ${env} environment for account ${i + 1}/${numAccounts}: ${address}`,
+        );
+      }
+
+      // Store the account information
       accountData.push({
         accountAddress: address,
-        inboxId,
         privateKey,
         encryptionKey: encryptionKeyHex,
+        clients: clientsInfo,
       });
 
       // Write the data to a JSON file
-      fs.writeFileSync(
-        `./logs/generated-inboxes.json`,
-        JSON.stringify(accountData, null, 2),
-      );
-      console.log(`Created account ${i + 1}/${numAccounts}: ${address}`);
+      fs.writeFileSync(outputFile, JSON.stringify(accountData, null, 2));
     } catch (error: unknown) {
       console.error(`Error creating XMTP client for account ${i + 1}:`, error);
     }
@@ -65,7 +184,16 @@ async function main() {
   console.log(
     `Successfully generated ${accountData.length} accounts with XMTP clients`,
   );
-  console.log(`Data saved to generated-inboxes.json`);
+  console.log(`Data saved to ${outputFile}`);
+  console.log(`All data stored in folder: ${LOGPATH}`);
 }
 
 main().catch(console.error);
+
+function verifyStorage(logPath: string) {
+  // Create db directory if it doesn't exist
+  if (!fs.existsSync(logPath)) {
+    console.log(`Creating directory: ${logPath}...`);
+    fs.mkdirSync(logPath, { recursive: true });
+  }
+}

--- a/scripts/local-update.ts
+++ b/scripts/local-update.ts
@@ -139,9 +139,4 @@ async function main() {
   }
 }
 
-// Run the script
-main().catch((error) => {
-  console.error("Unhandled error:");
-  console.error(error);
-  process.exit(1);
-});
+main().catch(console.error);

--- a/scripts/local-update.ts
+++ b/scripts/local-update.ts
@@ -1,0 +1,147 @@
+import * as fs from "fs";
+import path from "path";
+import {
+  createSigner,
+  getEncryptionKeyFromHex,
+  loadEnv,
+} from "@helpers/client";
+import generatedInboxes from "@helpers/generated-inboxes.json";
+import { Client, type XmtpEnv } from "@helpers/types";
+
+// Set constants
+const BASE_LOGPATH = "./logs";
+const SCRIPT_NAME = "local-update";
+const ENV: XmtpEnv = "local";
+
+// Load environment
+loadEnv(SCRIPT_NAME);
+
+// Function to ensure the log directory exists
+function verifyStorage(logPath: string) {
+  if (!fs.existsSync(logPath)) {
+    console.log(`Creating directory: ${logPath}...`);
+    fs.mkdirSync(logPath, { recursive: true });
+  }
+}
+
+// Main function to update local inboxes
+async function main() {
+  console.log("Starting local inbox update...");
+
+  // Check if there are any generated inboxes
+  if (!generatedInboxes || generatedInboxes.length === 0) {
+    console.error(
+      "Error: No generated inboxes found in @helpers/generated-inboxes.json",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Found ${generatedInboxes.length} inboxes to initialize in local environment`,
+  );
+
+  // Create a folder name based on count and environment
+  const folderName = `db-generated-${generatedInboxes.length}-${ENV}`;
+  const LOGPATH = `${BASE_LOGPATH}/${folderName}`;
+
+  // Ensure the log directory exists
+  verifyStorage(LOGPATH);
+
+  // Keep track of successful and failed inboxes
+  const results = {
+    success: 0,
+    failed: 0,
+    inboxIds: [] as string[],
+  };
+
+  console.log(`Processing inboxes and storing data in: ${LOGPATH}`);
+
+  // Create a timestamp for the output file
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputFile = `${LOGPATH}/local-inboxes-${timestamp}.json`;
+
+  // Array to store updated account data
+  const accountData = [];
+
+  // Process each inbox
+  for (let i = 0; i < generatedInboxes.length; i++) {
+    const inbox = generatedInboxes[i];
+    try {
+      // Create signer from private key
+      const signer = createSigner(inbox.privateKey as `0x${string}`);
+
+      // Get encryption key from hex
+      const encryptionKey = getEncryptionKeyFromHex(inbox.encryptionKey);
+
+      // Create a database path in the logs directory
+      const dbPath = `${LOGPATH}/${ENV}-${inbox.accountAddress}`;
+
+      console.log(
+        `Initializing inbox ${i + 1}/${generatedInboxes.length}: ${inbox.accountAddress}`,
+      );
+      console.log(`Using database path: ${dbPath}`);
+
+      // Create client in local environment
+      const client = await Client.create(signer, encryptionKey, {
+        dbPath: dbPath,
+        env: ENV,
+      });
+
+      // Verify the inbox ID matches what we expect
+      if (client.inboxId !== inbox.inboxId) {
+        console.warn(`Warning: Inbox ID mismatch for ${inbox.accountAddress}`);
+        console.warn(`  Expected: ${inbox.inboxId}`);
+        console.warn(`  Actual: ${client.inboxId}`);
+      }
+
+      // Store the updated account information
+      accountData.push({
+        accountAddress: inbox.accountAddress,
+        inboxId: client.inboxId,
+        privateKey: inbox.privateKey,
+        encryptionKey: inbox.encryptionKey,
+        dbPath: dbPath,
+      });
+
+      // Write the data to a JSON file after each successful initialization
+      fs.writeFileSync(outputFile, JSON.stringify(accountData, null, 2));
+
+      // Record the successful initialization
+      results.success++;
+      results.inboxIds.push(client.inboxId);
+
+      console.log(`✅ Successfully initialized inbox: ${inbox.accountAddress}`);
+    } catch (error) {
+      results.failed++;
+      console.error(`❌ Error initializing inbox ${inbox.accountAddress}:`);
+      console.error(error instanceof Error ? error.message : String(error));
+    }
+
+    // Add a separator between inbox initializations
+    console.log("-----------------------------------------------------");
+  }
+
+  // Display summary
+  console.log("\n=== Local Inbox Update Summary ===");
+  console.log(`Total inboxes processed: ${generatedInboxes.length}`);
+  console.log(`Successfully initialized: ${results.success}`);
+  console.log(`Failed to initialize: ${results.failed}`);
+  console.log(`All data stored in: ${LOGPATH}`);
+  console.log(`Data saved to: ${outputFile}`);
+
+  if (results.success > 0) {
+    console.log(
+      "\nThese inboxes are now ready to use in your local XMTP environment.",
+    );
+    console.log(
+      "You can use them in the stress test by setting XMTP_ENV=local in your .env file.",
+    );
+  }
+}
+
+// Run the script
+main().catch((error) => {
+  console.error("Unhandled error:");
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Update bot command syntax and improve inbox generation scripts to support multiple XMTP environments
* Modifies bot command syntax from colon-separated to space-separated format in [bots/README.md](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-054a2e2a6e2d5206cd32e5046440f1aeaf4158f23e25e2f4c0d95acb389119c9) and [bots/stress/README.md](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-ef409be3183c2ecfbf11a2a327443a3460bece8988adf62c9cdfe791869c29d8)
* Removes bot's inbox ID from group creation logic in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f) and [bots/test/commands.ts](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-9d850759d826ec03cb7d8f45698669d9464509fe8e30a9ef5af07d72f3a5f4e2)
* Rewrites [scripts/generate.ts](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-cffa3b4b6eebd8534cc4c1cf00ea3039d83fc1dcc87bbab40950cee3ce4555a0) to add interactive prompts, environment-specific account generation, and structured data storage
* Adds new [scripts/local-update.ts](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-52f3e38d7b0a7ed65ce6afa5afd5a2b70fa51040c88430d669c37707b23ca878) for initializing and verifying local environment inboxes

#### 📍Where to Start
Start with the rewritten account generation logic in [scripts/generate.ts](https://github.com/xmtp/xmtp-qa-testing/pull/133/files#diff-cffa3b4b6eebd8534cc4c1cf00ea3039d83fc1dcc87bbab40950cee3ce4555a0), which contains the core changes for supporting multiple XMTP environments and provides the foundation for the local environment inbox updates.

----

_[Macroscope](https://app.macroscope.com) summarized b902c0e._