### PR TITLE
Multi binding performance test

### DIFF
--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -19,7 +19,7 @@ describe(testName, () => {
 
   beforeAll(async () => {
     try {
-      workers = await getWorkers(["bob"], testName);
+      workers = await getWorkers(["bob-a-105"], testName);
       expect(workers).toBeDefined();
       expect(workers.getWorkers().length).toBe(1);
     } catch (e) {

--- a/suites/TS_Performance.test.ts
+++ b/suites/TS_Performance.test.ts
@@ -41,16 +41,16 @@ describe(testName, () => {
     try {
       workers = await getWorkers(
         [
-          "henry",
-          "ivy",
-          "jack",
-          "karen",
-          "randomguy",
-          "randomguy2",
-          "larry",
-          "mary",
-          "nancy",
-          "oscar",
+          "henry-a-100",
+          "ivy-a-100",
+          "jack-a-202",
+          "karen-a-100",
+          "randomguy-a-100",
+          "randomguy2-a-100",
+          "larry-a-100",
+          "mary-a-105",
+          "nancy-a-100",
+          "oscar-a-105",
         ],
         testName,
       );
@@ -115,7 +115,7 @@ describe(testName, () => {
         ],
         client.get("randomclient")!.env,
       );
-      expect(canMessage.get(randomAddress)).toBe(true);
+      expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
     } catch (e) {
       hasFailures = logError(e, expect);
       throw e;


### PR DESCRIPTION
### Update worker identifiers and implement case-insensitive address matching in GM bot and performance tests
* Updates worker identifier from `"bob"` to `"bob-a-105"` in the `getWorkers` function within [TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/141/files#diff-8926b702250dc4b4d7dfcaab5ae0f36b1d2013a5f02457d8df22d2643a646c06)
* Implements case-insensitive address comparison in the `canMessage` test by using `toLowerCase()` method in [TS_Performance.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/141/files#diff-b343eb331ec829b0d6ae82497b473ed93cc483e2c9c170f47b79a233b39ee873)

#### 📍Where to Start
Start with the `canMessage` test in [TS_Performance.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/141/files#diff-b343eb331ec829b0d6ae82497b473ed93cc483e2c9c170f47b79a233b39ee873) as it contains the most significant functional change with the case-insensitive address matching implementation.

----

_[Macroscope](https://app.macroscope.com) summarized 4bba00c._