### PR TITLE
Clarify README for XMTP group testing purpose

### DIFF
--- a/bugs/bug_fork/README.md
+++ b/bugs/bug_fork/README.md
@@ -1,6 +1,21 @@
 # Fork testing in XMTP
 
-This test is designed to test the XMTP groups with multiple users.
+This test is designed to test the XMTP groups with 12 clients.
+
+- 8 bots (running on latest node-sdk version)
+- 4 manual users (convos io, convos desktop, xmtpchat web and CB build IOS)
+
+## Setup
+
+```bash
+git clone https://github.com/xmtp/xmtp-qa-testing
+cd xmtp-qa-testing
+yarn install
+```
+
+## Environment variables
+
+Create a `.env` file in the `bugs/bug_fork` directory and set the following variables:
 
 ```bash
 LOGGING_LEVEL="off" # debug, info, warn, error

--- a/bugs/bug_fork/README.md
+++ b/bugs/bug_fork/README.md
@@ -1,6 +1,6 @@
-# Chaos fork testing in XMTP
+# Fork testing in XMTP
 
-This test is designed to test the robustness of the XMTP group protocol under various failure conditions.
+This test is designed to test the XMTP groups with multiple users.
 
 ```bash
 LOGGING_LEVEL="off" # debug, info, warn, error


### PR DESCRIPTION
### Update XMTP group testing README to reflect focus on multi-user testing rather than failure conditions
Updates the documentation in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/145/files#diff-c4b972db823245f52cd167d23c979f8e21f7ad3db27e356fff87c890cdad6203) to clarify the purpose of the XMTP group testing, removing references to failure condition testing and focusing on multi-user testing scenarios.

#### 📍Where to Start
Begin by reviewing the changes in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/145/files#diff-c4b972db823245f52cd167d23c979f8e21f7ad3db27e356fff87c890cdad6203) which contains the updated test description and purpose.

----

_[Macroscope](https://app.macroscope.com) summarized 29d831b._