### PR TITLE
Update cron schedule for more frequent performance checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,7 +54,7 @@ it(`createGroup-${i}: should create a large group of ${i} participants ${i}`, as
 
 The [`TS_Performance.yml`](/.github/workflows/TS_Performance.yml) workflow automates this test suite:
 
-- ⏱️ **Schedule**: Runs every 30 minutes via cron schedule
+- ⏱️ **Schedule**: Runs every 15 minutes via cron schedule
 - ⚙️ **Configuration**: Supports adjustable batch size and group size parameters
 - 🔄 **Retry Mechanism**: Implements retry logic for test stability
 - 📊 **Metrics**: Reports comprehensive performance metrics to Datadog

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,14 @@
 
 This document provides a comprehensive overview of the XMTP testing infrastructure, organized by test suites and their associated workflows and monitoring dashboards.
 
+## Table of Contents
+
+- [TS_Performance Test Suite](#-ts_performance-test-suite)
+- [TS_Delivery Test Suite](#-ts_delivery-test-suite)
+- [TS_Gm Test Suite](#-ts_gm-test-suite)
+- [Package Compatibility](#-package-compatibility)
+- [Agent Examples](#-agent-examples)
+
 ## 🚀 TS_Performance Test Suite
 
 The TS_Performance test suite comprehensively measures XMTP network performance across various operations, providing critical insights into system scalability and responsiveness.
@@ -67,7 +75,7 @@ The [`TS_Geolocation.yml`](/.github/workflows/TS_Geolocation.yml) workflow repli
 
 ### Monitoring Dashboard
 
-> Performance metrics feed into the [SDK Performance Dashboard](https://app.datadoghq.com/dashboard/9z2-in4-3we/), which visualizes:
+Performance metrics feed into the [SDK Performance Dashboard](https://app.datadoghq.com/dashboard/9z2-in4-3we/), which visualizes:
 
 ![TS_Performance](/media/ts_performance.png)
 
@@ -79,7 +87,7 @@ The [`TS_Geolocation.yml`](/.github/workflows/TS_Geolocation.yml) workflow repli
 
 The test suite reports detailed performance metrics via the `xmtp.sdk.duration` metric:
 
-```tsx
+```javascript
 // Send main operation metric
 const durationMetricName = `xmtp.sdk.duration`;
 
@@ -105,7 +113,7 @@ For each operation, the test suite tracks network performance across five key ph
 | `processing`     | Processing time (calculated as server_call - tls_handshake) |
 | `server_call`    | Server response time                                        |
 
-```tsx
+```javascript
 const networkStats = await getNetworkStats();
 
 for (const [statName, statValue] of Object.entries(networkStats)) {
@@ -187,7 +195,7 @@ The [`TS_Delivery.yml`](/.github/workflows/TS_Delivery.yml) workflow automates t
 - 🔍 **Error Handling**: Uses sophisticated filtering for transient issues
 - 🔄 **Retry Logic**: Implements up to 3 retry attempts for stability
 - 📊 **Metrics**: Sends detailed metrics to Datadog for tracking
-- ⚙️ **Configuration**: Supports adjustable message volume via environment variables
+- ⚙️ **Parameters**: Supports adjustable message volume via environment variables
 
 ### Monitoring Dashboard
 
@@ -195,7 +203,7 @@ The [`TS_Delivery.yml`](/.github/workflows/TS_Delivery.yml) workflow automates t
 
 The test suite reports delivery reliability via the `xmtp.sdk.delivery` metric:
 
-```tsx
+```javascript
 // Send delivery rate metric
 metrics.gauge("xmtp.sdk.delivery", deliveryRate, [
   `libxmtp:${firstWorker.version}`,
@@ -227,9 +235,8 @@ The test suite evaluates:
 
 Key implementation highlights:
 
-The Playwright helper function facilitates browser-based testing:
-
 ```javascript
+// Playwright helper function for browser-based testing
 await page.goto(`https://xmtp.chat/`);
 await page.getByRole("main").getByRole("button", { name: "Connect" }).click();
 await page
@@ -272,11 +279,11 @@ The [`TS_Gm.yml`](/.github/workflows/TS_Gm.yml) workflow automates the test suit
 - 🔍 **Regression Testing**: Compares behavior across different SDK versions
 - 🌐 **Browser Testing**: Includes Playwright-based browser automation tests
 
-## 📦 Package compatibility
+## 📦 Package Compatibility
 
 The package compatibility workflow validates that our codebase works correctly across different Node.js versions and package managers, ensuring broad compatibility across developer environments.
 
-### Implementation details
+### Implementation Details
 
 This workflow tests:
 
@@ -286,21 +293,21 @@ This workflow tests:
 - Build process completion
 - Basic client connectivity check
 
-### Associated workflow
+### Associated Workflow
 
 The [`test-package-compatibility.yml`](/.github/workflows/test-package-compatibility.yml) workflow:
 
 - 🚀 **Trigger**: Runs on every commit to main branch or manual dispatch
-- 📊 **Matrix testing**: Tests combinations of Node.js versions and package managers
-- 🔄 **Environment setup**: Configures appropriate package manager in each job
-- 🔍 **Failure isolation**: Uses fail-fast: false to identify specific failing combinations
+- 📊 **Matrix Testing**: Tests combinations of Node.js versions and package managers
+- 🔄 **Environment Setup**: Configures appropriate package manager in each job
+- 🔍 **Failure Isolation**: Uses fail-fast: false to identify specific failing combinations
 - 👁️ **Verification**: Performs a client connection check to validate functionality
 
-## 🤖 Agent examples
+## 🤖 Agent Examples
 
-The agent examples workflow tests the xmtp-agent-examples repository functionality, ensuring that code examples are valid and operational.
+The agent examples workflow tests the [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples/) repository functionality, ensuring that code examples are valid and operational.
 
-### Implementation details
+### Implementation Details
 
 This workflow:
 
@@ -309,12 +316,12 @@ This workflow:
 - Tests the agent's ability to initialize and connect to XMTP
 - Validates that the agent reaches the "waiting for messages" state
 
-### Associated workflow
+### Associated Workflow
 
 The [`agent-examples.yml`](/.github/workflows/agent-examples.yml) workflow:
 
 - ⏱️ **Schedule**: Runs hourly via cron schedule
-- 🧪 **Test environment**: Configures the environment with appropriate secrets
-- 🔄 **Timeout control**: Uses a 20-second timeout to avoid long-running jobs
-- 🔍 **Success verification**: Checks for the "Waiting for messages..." message
-- 👁️ **Error detection**: Reports and fails if agent doesn't initialize correctly
+- 🧪 **Test Environment**: Configures the environment with appropriate secrets
+- 🔄 **Timeout Control**: Uses a 20-second timeout to avoid long-running jobs
+- 🔍 **Success Verification**: Checks for the "Waiting for messages..." message
+- 👁️ **Error Detection**: Reports and fails if agent doesn't initialize correctly

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,17 +2,6 @@
 
 This document provides a comprehensive overview of the XMTP testing infrastructure, organized by test suites and their associated workflows and monitoring dashboards.
 
-## Test Suites Overview
-
-| Test suite     | Status                                                                                                                                                                                                    | Run frequency |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| 🚀 Performance | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml)                         | Every 30 min  |
-| 📬 Delivery    | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Delivery.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Delivery.yml)                               | Every 30 min  |
-| 👋 Gm          | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Gm.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Gm.yml)                                           | Every 30 min  |
-| 🌎 Geolocation | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Geolocation.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Geolocation.yml)                         | Every 30 min  |
-| 📦 Package     | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/test-package-compatibility.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/test-package-compatibility.yml) | On commit     |
-| 🤖 Agent       | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/agent-examples.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/agent-examples.yml)                         | Hourly        |
-
 ## 🚀 TS_Performance Test Suite
 
 The TS_Performance test suite comprehensively measures XMTP network performance across various operations, providing critical insights into system scalability and responsiveness.

--- a/.github/workflows/TS_Performance.yml
+++ b/.github/workflows/TS_Performance.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [deploy]
   schedule:
-    - cron: "30 * * * *" # Runs at 30 minutes past each hour
+    - cron: "*/15 * * * *" # Runs every 15 minutes
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Test suite        | Status                                                                                                                                                                                        | Run frequency |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| 🚀 Performance    | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml)             | Every 30 min  |
+| 🚀 Performance    | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Performance.yml)             | Every 15 min  |
 | 📬 Delivery       | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Delivery.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Delivery.yml)                   | Every 30 min  |
 | 👋 Gm             | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Gm.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Gm.yml)                               | Every 30 min  |
 | 🌎 Geolocation    | [![Status](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Geolocation.yml/badge.svg)](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Geolocation.yml)             | Every 30 min  |

--- a/bugs/bug_fork/forked.log
+++ b/bugs/bug_fork/forked.log
@@ -1,0 +1,65 @@
+[2025-04-20T22:16:08.771Z] [info] bob: Worker created (100-c205eec) - 0x40E9E4Bf6438f44d548F2F67bB0da5CBf017F5B3
+[2025-04-20T22:16:08.771Z] [info] alice: Worker created (105-6eb1ce4) - 0x30C1D124607B177B0228a1e3ED8117a1B60fFF6C
+[2025-04-20T22:16:08.835Z] [info] eve: Worker created (105-6eb1ce4) - 0xfe37AA5CccC9a5C065cDaeeC7b4cE2Ad9B1F2658
+[2025-04-20T22:16:08.941Z] [info] ivy: Worker created (202-bed98df) - 0xd180C66d439BaF194336155E0038226d87c60954
+[2025-04-20T22:16:09.067Z] [info] dave: Worker created (203-c24af30) - 0x08ed606A1398bc2D6FD2F4463582BF3D597bb57b
+[2025-04-20T22:16:09.925Z] [info] Fetching group with ID bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:16:09.927Z] [info] Group bfda457394be0826f32a8eb2ed363c5d has 9 members
+[2025-04-20T22:16:11.734Z] [info] getOrCreateGroup - Duration: 1808.8730420000002ms
+[2025-04-20T22:16:11.734Z] [warn] getOrCreateGroup 1.809s
+[2025-04-20T22:16:12.366Z] [info] alice sending: "alice:1" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:16:13.444Z] [info] sendMessageToGroup for alice - Duration: 1709.7114579999998ms
+[2025-04-20T22:16:13.444Z] [warn] sendMessageToGroup-alice 1.710s
+[2025-04-20T22:16:13.445Z] [info] bob will add/remove alice
+[2025-04-20T22:16:18.313Z] [info] Epoch 0 - Duration: 3765.477834000001ms
+[2025-04-20T22:16:18.313Z] [warn] Epoch 0 done
+[2025-04-20T22:16:21.593Z] [info] Epoch 1 - Duration: 3279.8903329999994ms
+[2025-04-20T22:16:21.593Z] [warn] Epoch 1 done
+[2025-04-20T22:16:25.168Z] [info] Epoch 2 - Duration: 3573.8613330000007ms
+[2025-04-20T22:16:25.168Z] [warn] Epoch 2 done
+[2025-04-20T22:16:28.660Z] [info] Epoch 3 - Duration: 3491.382125ms
+[2025-04-20T22:16:28.660Z] [warn] Epoch 3 done
+[2025-04-20T22:16:32.156Z] [info] Epoch 4 - Duration: 3495.877792000003ms
+[2025-04-20T22:16:32.156Z] [warn] Epoch 4 done
+[2025-04-20T22:16:35.414Z] [info] Epoch 5 - Duration: 3257.1659999999974ms
+[2025-04-20T22:16:35.415Z] [warn] Epoch 5 done
+[2025-04-20T22:16:35.415Z] [info] membershipChange for bob and alice - Duration: 21970.27175ms
+[2025-04-20T22:16:35.415Z] [warn] membershipChange-bob-alice 21.971s
+[2025-04-20T22:16:36.230Z] [info] eve sending: "eve:2" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:16:37.524Z] [info] sendMessageToGroup for eve - Duration: 2108.7834169999987ms
+[2025-04-20T22:16:37.525Z] [warn] sendMessageToGroup-eve 2.109s
+[2025-04-20T22:16:37.525Z] [info] bob will add/remove eve
+[2025-04-20T22:16:42.055Z] [info] Epoch 0 - Duration: 3461.595583999995ms
+[2025-04-20T22:16:42.055Z] [warn] Epoch 0 done
+[2025-04-20T22:16:45.295Z] [info] Epoch 1 - Duration: 3239.4800410000025ms
+[2025-04-20T22:16:45.295Z] [warn] Epoch 1 done
+[2025-04-20T22:16:48.468Z] [info] Epoch 2 - Duration: 3172.772250000002ms
+[2025-04-20T22:16:48.468Z] [warn] Epoch 2 done
+[2025-04-20T22:16:51.567Z] [info] Epoch 3 - Duration: 3097.725249999996ms
+[2025-04-20T22:16:51.567Z] [warn] Epoch 3 done
+[2025-04-20T22:16:55.147Z] [info] Epoch 4 - Duration: 3579.6351249999934ms
+[2025-04-20T22:16:55.147Z] [warn] Epoch 4 done
+[2025-04-20T22:16:58.687Z] [info] Epoch 5 - Duration: 3540.3639580000017ms
+[2025-04-20T22:16:58.687Z] [warn] Epoch 5 done
+[2025-04-20T22:16:58.687Z] [info] membershipChange for bob and eve - Duration: 21162.664167000003ms
+[2025-04-20T22:16:58.687Z] [warn] membershipChange-bob-eve 21.163s
+[2025-04-20T22:16:59.440Z] [info] ivy sending: "ivy:3" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:17:00.417Z] [info] sendMessageToGroup for ivy - Duration: 1729.4612500000003ms
+[2025-04-20T22:17:00.417Z] [warn] sendMessageToGroup-ivy 1.730s
+[2025-04-20T22:17:00.417Z] [info] bob will add/remove ivy
+[2025-04-20T22:17:04.719Z] [info] Epoch 0 - Duration: 3269.777374999998ms
+[2025-04-20T22:17:04.719Z] [warn] Epoch 0 done
+[2025-04-20T22:17:08.080Z] [info] Epoch 1 - Duration: 3360.573583000005ms
+[2025-04-20T22:17:08.080Z] [warn] Epoch 1 done
+[2025-04-20T22:17:11.577Z] [info] Epoch 2 - Duration: 3496.395792000003ms
+[2025-04-20T22:17:11.577Z] [warn] Epoch 2 done
+[2025-04-20T22:17:14.834Z] [info] Epoch 3 - Duration: 3256.966625000001ms
+[2025-04-20T22:17:14.834Z] [warn] Epoch 3 done
+[2025-04-20T22:17:18.416Z] [info] Epoch 4 - Duration: 3581.845166999992ms
+[2025-04-20T22:17:18.416Z] [warn] Epoch 4 done
+[2025-04-20T22:17:21.827Z] [info] Epoch 5 - Duration: 3410.480416999999ms
+[2025-04-20T22:17:21.827Z] [warn] Epoch 5 done
+[2025-04-20T22:17:21.827Z] [info] membershipChange for bob and ivy - Duration: 21409.51275ms
+[2025-04-20T22:17:21.827Z] [warn] membershipChange-bob-ivy 21.410s
+[2025-04-20T22:17:22.625Z] [info] initialize workers and create group - Duration: 76083.80158300001ms
+[2025-04-20T22:17:22.625Z] [warn] initialize workers and create group 1:16.084 (m:ss.mmm)

--- a/bugs/bug_fork/test.log
+++ b/bugs/bug_fork/test.log
@@ -1,65 +1,32 @@
-[2025-04-20T22:16:08.771Z] [info] bob: Worker created (100-c205eec) - 0x40E9E4Bf6438f44d548F2F67bB0da5CBf017F5B3
-[2025-04-20T22:16:08.771Z] [info] alice: Worker created (105-6eb1ce4) - 0x30C1D124607B177B0228a1e3ED8117a1B60fFF6C
-[2025-04-20T22:16:08.835Z] [info] eve: Worker created (105-6eb1ce4) - 0xfe37AA5CccC9a5C065cDaeeC7b4cE2Ad9B1F2658
-[2025-04-20T22:16:08.941Z] [info] ivy: Worker created (202-bed98df) - 0xd180C66d439BaF194336155E0038226d87c60954
-[2025-04-20T22:16:09.067Z] [info] dave: Worker created (203-c24af30) - 0x08ed606A1398bc2D6FD2F4463582BF3D597bb57b
-[2025-04-20T22:16:09.925Z] [info] Fetching group with ID bfda457394be0826f32a8eb2ed363c5d
-[2025-04-20T22:16:09.927Z] [info] Group bfda457394be0826f32a8eb2ed363c5d has 9 members
-[2025-04-20T22:16:11.734Z] [info] getOrCreateGroup - Duration: 1808.8730420000002ms
-[2025-04-20T22:16:11.734Z] [warn] getOrCreateGroup 1.809s
-[2025-04-20T22:16:12.366Z] [info] alice sending: "alice:1" to group bfda457394be0826f32a8eb2ed363c5d
-[2025-04-20T22:16:13.444Z] [info] sendMessageToGroup for alice - Duration: 1709.7114579999998ms
-[2025-04-20T22:16:13.444Z] [warn] sendMessageToGroup-alice 1.710s
-[2025-04-20T22:16:13.445Z] [info] bob will add/remove alice
-[2025-04-20T22:16:18.313Z] [info] Epoch 0 - Duration: 3765.477834000001ms
-[2025-04-20T22:16:18.313Z] [warn] Epoch 0 done
-[2025-04-20T22:16:21.593Z] [info] Epoch 1 - Duration: 3279.8903329999994ms
-[2025-04-20T22:16:21.593Z] [warn] Epoch 1 done
-[2025-04-20T22:16:25.168Z] [info] Epoch 2 - Duration: 3573.8613330000007ms
-[2025-04-20T22:16:25.168Z] [warn] Epoch 2 done
-[2025-04-20T22:16:28.660Z] [info] Epoch 3 - Duration: 3491.382125ms
-[2025-04-20T22:16:28.660Z] [warn] Epoch 3 done
-[2025-04-20T22:16:32.156Z] [info] Epoch 4 - Duration: 3495.877792000003ms
-[2025-04-20T22:16:32.156Z] [warn] Epoch 4 done
-[2025-04-20T22:16:35.414Z] [info] Epoch 5 - Duration: 3257.1659999999974ms
-[2025-04-20T22:16:35.415Z] [warn] Epoch 5 done
-[2025-04-20T22:16:35.415Z] [info] membershipChange for bob and alice - Duration: 21970.27175ms
-[2025-04-20T22:16:35.415Z] [warn] membershipChange-bob-alice 21.971s
-[2025-04-20T22:16:36.230Z] [info] eve sending: "eve:2" to group bfda457394be0826f32a8eb2ed363c5d
-[2025-04-20T22:16:37.524Z] [info] sendMessageToGroup for eve - Duration: 2108.7834169999987ms
-[2025-04-20T22:16:37.525Z] [warn] sendMessageToGroup-eve 2.109s
-[2025-04-20T22:16:37.525Z] [info] bob will add/remove eve
-[2025-04-20T22:16:42.055Z] [info] Epoch 0 - Duration: 3461.595583999995ms
-[2025-04-20T22:16:42.055Z] [warn] Epoch 0 done
-[2025-04-20T22:16:45.295Z] [info] Epoch 1 - Duration: 3239.4800410000025ms
-[2025-04-20T22:16:45.295Z] [warn] Epoch 1 done
-[2025-04-20T22:16:48.468Z] [info] Epoch 2 - Duration: 3172.772250000002ms
-[2025-04-20T22:16:48.468Z] [warn] Epoch 2 done
-[2025-04-20T22:16:51.567Z] [info] Epoch 3 - Duration: 3097.725249999996ms
-[2025-04-20T22:16:51.567Z] [warn] Epoch 3 done
-[2025-04-20T22:16:55.147Z] [info] Epoch 4 - Duration: 3579.6351249999934ms
-[2025-04-20T22:16:55.147Z] [warn] Epoch 4 done
-[2025-04-20T22:16:58.687Z] [info] Epoch 5 - Duration: 3540.3639580000017ms
-[2025-04-20T22:16:58.687Z] [warn] Epoch 5 done
-[2025-04-20T22:16:58.687Z] [info] membershipChange for bob and eve - Duration: 21162.664167000003ms
-[2025-04-20T22:16:58.687Z] [warn] membershipChange-bob-eve 21.163s
-[2025-04-20T22:16:59.440Z] [info] ivy sending: "ivy:3" to group bfda457394be0826f32a8eb2ed363c5d
-[2025-04-20T22:17:00.417Z] [info] sendMessageToGroup for ivy - Duration: 1729.4612500000003ms
-[2025-04-20T22:17:00.417Z] [warn] sendMessageToGroup-ivy 1.730s
-[2025-04-20T22:17:00.417Z] [info] bob will add/remove ivy
-[2025-04-20T22:17:04.719Z] [info] Epoch 0 - Duration: 3269.777374999998ms
-[2025-04-20T22:17:04.719Z] [warn] Epoch 0 done
-[2025-04-20T22:17:08.080Z] [info] Epoch 1 - Duration: 3360.573583000005ms
-[2025-04-20T22:17:08.080Z] [warn] Epoch 1 done
-[2025-04-20T22:17:11.577Z] [info] Epoch 2 - Duration: 3496.395792000003ms
-[2025-04-20T22:17:11.577Z] [warn] Epoch 2 done
-[2025-04-20T22:17:14.834Z] [info] Epoch 3 - Duration: 3256.966625000001ms
-[2025-04-20T22:17:14.834Z] [warn] Epoch 3 done
-[2025-04-20T22:17:18.416Z] [info] Epoch 4 - Duration: 3581.845166999992ms
-[2025-04-20T22:17:18.416Z] [warn] Epoch 4 done
-[2025-04-20T22:17:21.827Z] [info] Epoch 5 - Duration: 3410.480416999999ms
-[2025-04-20T22:17:21.827Z] [warn] Epoch 5 done
-[2025-04-20T22:17:21.827Z] [info] membershipChange for bob and ivy - Duration: 21409.51275ms
-[2025-04-20T22:17:21.827Z] [warn] membershipChange-bob-ivy 21.410s
-[2025-04-20T22:17:22.625Z] [info] initialize workers and create group - Duration: 76083.80158300001ms
-[2025-04-20T22:17:22.625Z] [warn] initialize workers and create group 1:16.084 (m:ss.mmm)
+[2025-04-20T22:38:17.858Z] [info] dave: Worker created (203-c24af30) - 0x08ed606A1398bc2D6FD2F4463582BF3D597bb57b
+[2025-04-20T22:38:17.859Z] [info] eve: Worker created (105-6eb1ce4) - 0xfe37AA5CccC9a5C065cDaeeC7b4cE2Ad9B1F2658
+[2025-04-20T22:38:17.867Z] [info] alice: Worker created (105-6eb1ce4) - 0x30C1D124607B177B0228a1e3ED8117a1B60fFF6C
+[2025-04-20T22:38:18.061Z] [info] ivy: Worker created (202-bed98df) - 0xd180C66d439BaF194336155E0038226d87c60954
+[2025-04-20T22:38:18.072Z] [info] bob: Worker created (100-c205eec) - 0x40E9E4Bf6438f44d548F2F67bB0da5CBf017F5B3
+[2025-04-20T22:38:18.534Z] [info] Fetching group with ID bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:38:18.541Z] [info] Group bfda457394be0826f32a8eb2ed363c5d has 9 members
+[2025-04-20T22:38:20.647Z] [info] getOrCreateGroup - Duration: 2112.76425ms
+[2025-04-20T22:38:20.648Z] [warn] getOrCreateGroup 2.113s
+[2025-04-20T22:38:21.528Z] [info] alice sending: "alice:1" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:38:22.758Z] [info] sendMessageToGroup for alice - Duration: 2109.5859999999993ms
+[2025-04-20T22:38:22.758Z] [warn] sendMessageToGroup-alice 2.110s
+[2025-04-20T22:38:22.758Z] [info] dave will add/remove alice
+[2025-04-20T22:38:27.063Z] [error] Error managing alice in bfda457394be0826f32a8eb2ed363c5d: {"code":"GenericFailure"}
+[2025-04-20T22:38:27.063Z] [info] membershipChange for dave and alice - Duration: 4304.917167ms
+[2025-04-20T22:38:27.063Z] [warn] membershipChange-dave-alice 4.305s
+[2025-04-20T22:38:28.216Z] [info] eve sending: "eve:2" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:38:29.317Z] [info] sendMessageToGroup for eve - Duration: 2253.4449170000007ms
+[2025-04-20T22:38:29.318Z] [warn] sendMessageToGroup-eve 2.254s
+[2025-04-20T22:38:29.318Z] [info] dave will add/remove eve
+[2025-04-20T22:38:32.829Z] [error] Error managing eve in bfda457394be0826f32a8eb2ed363c5d: {"code":"GenericFailure"}
+[2025-04-20T22:38:32.829Z] [info] membershipChange for dave and eve - Duration: 3511.0016659999983ms
+[2025-04-20T22:38:32.829Z] [warn] membershipChange-dave-eve 3.511s
+[2025-04-20T22:38:33.883Z] [info] ivy sending: "ivy:3" to group bfda457394be0826f32a8eb2ed363c5d
+[2025-04-20T22:38:35.364Z] [info] sendMessageToGroup for ivy - Duration: 2534.220041999997ms
+[2025-04-20T22:38:35.364Z] [warn] sendMessageToGroup-ivy 2.535s
+[2025-04-20T22:38:35.365Z] [info] dave will add/remove ivy
+[2025-04-20T22:38:38.549Z] [error] Error managing ivy in bfda457394be0826f32a8eb2ed363c5d: {"code":"GenericFailure"}
+[2025-04-20T22:38:38.549Z] [info] membershipChange for dave and ivy - Duration: 3184.825584000002ms
+[2025-04-20T22:38:38.549Z] [warn] membershipChange-dave-ivy 3.185s
+[2025-04-20T22:38:39.999Z] [info] initialize workers and create group - Duration: 24903.36075ms
+[2025-04-20T22:38:39.999Z] [warn] initialize workers and create group 24.904s


### PR DESCRIPTION
### Increase performance test suite monitoring frequency from 30 to 15 minutes in GitHub Actions workflow
Updates the cron schedule configuration and related documentation to run performance tests more frequently:

* Modifies cron schedule in [TS_Performance.yml](https://github.com/xmtp/xmtp-qa-testing/pull/151/files#diff-9400d484963f10f3b13b82476765a9352d928964c4e788df8f272ce591a7eb2d) from `30 * * * *` to `*/15 * * * *`
* Updates test suite documentation in [workflows/README.md](https://github.com/xmtp/xmtp-qa-testing/pull/151/files#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffb) with restructured content and new schedule
* Reflects schedule change in main [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/151/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) status table
* Adds new test run logs in `bugs/bug_fork` directory documenting group membership operations

#### 📍Where to Start
Start with the cron schedule modification in [TS_Performance.yml](https://github.com/xmtp/xmtp-qa-testing/pull/151/files#diff-9400d484963f10f3b13b82476765a9352d928964c4e788df8f272ce591a7eb2d) which contains the core functional change to the test execution frequency.

----

_[Macroscope](https://app.macroscope.com) summarized ed27324._