### PR TITLE
Add correlation to fork issue

### DIFF
--- a/bugs/bug_fork/README.md
+++ b/bugs/bug_fork/README.md
@@ -81,3 +81,11 @@ for (let i = 0; i <= trys; i++) {
 - In the forked state, push notifications still come through to Coinbase Wallet
 - Total SDK calls = 1 + (1 + 1 + 1) + 1 + 3×(1 + 1 + 1) + 3×(1 + 1 + 1 + 6×2) + 1 = 51 calls
   - Some times hitting API limits
+ 
+
+## Potential correlation
+
+> Between the fork and the SDK performance when close to 1 second client creations
+
+![CleanShot 2025-04-20 at 21 07 59@2x](https://github.com/user-attachments/assets/e3836192-1be5-44bf-8738-3b15a185b842)
+


### PR DESCRIPTION
### Document correlation between fork issue and 1-second SDK client creation intervals in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/154/files#diff-c4b972db823245f52cd167d23c979f8e21f7ad3db27e356fff87c890cdad6203)
Updates the bug documentation in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/154/files#diff-c4b972db823245f52cd167d23c979f8e21f7ad3db27e356fff87c890cdad6203) with a new "Potential correlation" section that includes evidence of timing patterns between SDK client creations and fork issues, supported by a screenshot visualization.

#### 📍Where to Start
Begin by reviewing the new "Potential correlation" section in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/154/files#diff-c4b972db823245f52cd167d23c979f8e21f7ad3db27e356fff87c890cdad6203) which contains the documented findings and supporting screenshot.

----

_[Macroscope](https://app.macroscope.com) summarized fec41ed._