### PR TITLE
Increase timeout for GM response handling in tests

### DIFF
--- a/.github/workflows/validate-functional-tests.yml
+++ b/.github/workflows/validate-functional-tests.yml
@@ -21,6 +21,8 @@ jobs:
         run: yarn
       - name: Start dev environment
         run: ./dev/up
+      - name: Make test script executable
+        run: chmod +x ./scripts/run-test.sh
       - name: Run functional tests
         env:
           XMTP_ENV: dev

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -141,6 +141,8 @@ export class XmtpPlaywright {
     waitForMessage: boolean = true,
   ): Promise<boolean> {
     try {
+      // Wait for GM response with a longer timeout
+      await page?.waitForTimeout(1000);
       await page.getByRole("textbox", { name: "Type a message..." }).click();
       await page.getByRole("textbox", { name: "Type a message..." }).fill("hi");
       await page.getByRole("button", { name: "Send" }).click();

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -51,6 +51,7 @@ describe(testName, () => {
       await convo.sync();
       const messages = await convo.messages();
       const prevMessageCount = messages.length;
+      console.log("prevMessageCount", prevMessageCount);
       // Send a simple message
       const sentMessageId = await convo.send("gm");
       console.log("sentMessageId", sentMessageId);

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -40,7 +40,6 @@ describe(testName, () => {
 
   it("gm-bot: should check if bot is alive", async () => {
     try {
-      console.log("gmBotAddress", gmBotAddress);
       // Create conversation with the bot
       convo = await workers
         .get("bob")!
@@ -51,17 +50,13 @@ describe(testName, () => {
 
       await convo.sync();
       const prevMessages = await convo.messages();
-      console.log("prevMessages", prevMessages.length);
       // Send a simple message
       const sentMessageId = await convo.send("gm");
-      console.log("sentMessageId", sentMessageId);
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await convo.sync();
       const messages = await convo.messages();
-      console.log("messages", messages.length);
 
       const messagesAfter = messages.length;
-      console.log("messagesAfter", messagesAfter);
 
       await convo.sync();
       // We should have at least 2 messages (our message and bot's response)

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -40,6 +40,7 @@ describe(testName, () => {
 
   it("gm-bot: should check if bot is alive", async () => {
     try {
+      console.log("gmBotAddress", gmBotAddress);
       // Create conversation with the bot
       convo = await workers
         .get("bob")!
@@ -49,20 +50,22 @@ describe(testName, () => {
         });
 
       await convo.sync();
-      const prevMessages = (await convo.messages()).length;
-
+      const prevMessages = await convo.messages();
+      console.log("prevMessages", prevMessages.length);
       // Send a simple message
-      await convo.send("gm");
-
+      const sentMessageId = await convo.send("gm");
+      console.log("sentMessageId", sentMessageId);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       await convo.sync();
       const messages = await convo.messages();
-      await convo.sync();
+      console.log("messages", messages.length);
 
       const messagesAfter = messages.length;
+      console.log("messagesAfter", messagesAfter);
 
       await convo.sync();
       // We should have at least 2 messages (our message and bot's response)
-      expect(messagesAfter).toBe(prevMessages + 2);
+      expect(messagesAfter).toBe(prevMessages.length + 2);
       console.log("Messages before:", prevMessages, "after:", messagesAfter);
     } catch (e) {
       hasFailures = logError(e, expect);

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -49,19 +49,26 @@ describe(testName, () => {
         });
 
       await convo.sync();
-      const prevMessages = await convo.messages();
+      const messages = await convo.messages();
+      const prevMessageCount = messages.length;
       // Send a simple message
       const sentMessageId = await convo.send("gm");
+      console.log("sentMessageId", sentMessageId);
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      await convo.sync();
-      const messages = await convo.messages();
 
-      const messagesAfter = messages.length;
+      await convo.sync();
+      const messagesAfter = await convo.messages();
+      const messageAfterCount = messagesAfter.length;
 
       await convo.sync();
       // We should have at least 2 messages (our message and bot's response)
-      expect(messagesAfter).toBe(prevMessages.length + 2);
-      console.log("Messages before:", prevMessages, "after:", messagesAfter);
+      expect(messageAfterCount).toBe(prevMessageCount + 2);
+      console.log(
+        "Messages before:",
+        prevMessageCount,
+        "after:",
+        messageAfterCount,
+      );
     } catch (e) {
       hasFailures = logError(e, expect);
       throw e;


### PR DESCRIPTION
### Add 1000ms timeout to GM response handling in XmtpPlaywright.sendAndWaitForGm method and test workflow
* Adds execution permission to test script via `chmod +x` in [validate-functional-tests.yml](https://github.com/xmtp/xmtp-qa-testing/pull/166/files#diff-1eb759d150c81c4aa3964235566fc27a326fd0911f2f7cae688cd2af434ac872)
* Implements 1000ms timeout in `sendAndWaitForGm` method within [playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/166/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e)
* Updates message tracking logic in [TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/166/files#diff-8926b702250dc4b4d7dfcaab5ae0f36b1d2013a5f02457d8df22d2643a646c06) with improved count tracking, logging of message IDs, and sync calls

#### 📍Where to Start
Start with the `sendAndWaitForGm` method in [playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/166/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) which contains the core timeout change, then review the test implementation in [TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/166/files#diff-8926b702250dc4b4d7dfcaab5ae0f36b1d2013a5f02457d8df22d2643a646c06).

----

_[Macroscope](https://app.macroscope.com) summarized 7ba8466._