### PR TITLE
Update stress test commands for clarity and accuracy

### DIFF
--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -42,9 +42,9 @@ loadEnv(testName);
 
 export const HELP_TEXT = `Stress bot commands:
 
-/stress small - Run a small test: Creates a group with 20 members, 3 workers, 5 messages each
-/stress medium - Run a medium test: Creates a group with 50 members, 5 workers, 10 messages each
-/stress large - Run a large test: Creates a group with 100 members, 10 workers, 15 messages each`;
+/stress small - Run a small test: Creates a group with 20 members, large groups with 50 members, 20 workers, 5 messages each
+/stress medium - Run a medium test: Creates a group with 50 members, large groups up to 100 members, 50 workers, 10 messages each
+/stress large - Run a large test: Creates a group with 100 members, large groups up to 200 members, 100 workers, 15 messages each`;
 
 // Singleton lock to prevent multiple stress tests from running concurrently
 class StressTestLock {


### PR DESCRIPTION
### Update stress test command help text in `bots/stress/index.ts` to reflect new test parameters for member counts, group sizes and worker counts
The help text documentation for stress test commands has been revised with updated parameters:

* Small test now specifies 20 members in groups of 50, with 20 workers sending 5 messages each
* Medium test now indicates 50 members in groups up to 100, with 50 workers sending 10 messages each  
* Large test now describes 100 members in groups up to 200, with 100 workers sending 15 messages each

Changes are contained in [index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/169/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f)

#### 📍Where to Start
Review the command help text changes in [index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/169/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f)

----

_[Macroscope](https://app.macroscope.com) summarized 7d04764._