### PR TITLE
Adjust timeout for message sync in tests

### DIFF
--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -92,12 +92,6 @@ export async function verifyStream<T extends string = string>(
   // Send the messages with delays between them
   for (let i = 0; i < count; i++) {
     await sender(group, sentMessages[i]);
-    // Add a small delay between messages to avoid rate limiting
-    if (i < count - 1) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, defaultValues.perMessageTimeout),
-      );
-    }
   }
   console.log(`Sent ${count} messages`);
 
@@ -158,6 +152,11 @@ export async function verifyConversationStream(
   const createdGroup =
     await initiator.client.conversations.newGroup(participantAddresses);
   console.log(`[${initiator.name}] Created group: ${createdGroup.id}`);
+
+  // Give streams time to initialize before sending messages
+  await new Promise((resolve) =>
+    setTimeout(resolve, defaultValues.streamTimeout),
+  );
 
   // Wait for all notifications
   const results = await Promise.all(participantPromises);

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -646,7 +646,7 @@ export const defaultNames = [
 
 export const defaultValues = {
   amount: 5,
-  streamTimeout: 1000,
+  streamTimeout: 3000,
   timeout: 40000,
   perMessageTimeout: 3000,
   defaultNames,

--- a/suites/TS_Delivery.test.ts
+++ b/suites/TS_Delivery.test.ts
@@ -21,255 +21,245 @@ const receiverAmount = parseInt(
 console.log(
   `[${testName}] Amount of messages: ${amountofMessages}, Receivers: ${receiverAmount}`,
 );
-// 2 seconds per message, multiplied by the total number of participants
-// valiable for github actions
-const timeoutMax =
-  amountofMessages * receiverAmount * defaultValues.perMessageTimeout;
 
-describe(
-  testName,
-  () => {
-    let workers: WorkerManager;
-    let group: Group;
-    let collectedMessages: VerifyStreamResult;
-    const randomSuffix = Math.random().toString(36).substring(2, 15);
-    let hasFailures = false;
-    beforeAll(async () => {
-      try {
-        //fs.rmSync(".data", { recursive: true, force: true });
-        // Use getWorkers to spin up many workers. This is resource-intensive.
-        workers = await getWorkers(receiverAmount, testName);
-        console.log("creating group");
-        group = await workers
-          .get("bob")!
-          .client.conversations.newGroup([
-            ...workers.getWorkers().map((p) => p.client.inboxId),
-          ]);
+describe(testName, () => {
+  let workers: WorkerManager;
+  let group: Group;
+  let collectedMessages: VerifyStreamResult;
+  const randomSuffix = Math.random().toString(36).substring(2, 15);
+  let hasFailures = false;
+  beforeAll(async () => {
+    try {
+      //fs.rmSync(".data", { recursive: true, force: true });
+      // Use getWorkers to spin up many workers. This is resource-intensive.
+      workers = await getWorkers(receiverAmount, testName);
+      console.log("creating group");
+      group = await workers
+        .get("bob")!
+        .client.conversations.newGroup([
+          ...workers.getWorkers().map((p) => p.client.inboxId),
+        ]);
 
-        expect(workers).toBeDefined();
-        expect(workers.getWorkers().length).toBe(receiverAmount);
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
+      expect(workers).toBeDefined();
+      expect(workers.getWorkers().length).toBe(receiverAmount);
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      sendTestResults(hasFailures, testName);
+      await closeEnv(testName, workers);
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
+
+  it("tc_stream: send the stream", async () => {
+    try {
+      expect(group.id).toBeDefined();
+
+      // Collect messages by setting up listeners before sending and then sending known messages.
+      collectedMessages = await verifyStream(
+        group,
+        workers.getWorkers(),
+        "text",
+        amountofMessages,
+        (index) => `gm-${index + 1}-${randomSuffix}`,
+      );
+      expect(collectedMessages.allReceived).toBe(true);
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
+
+  it("tc_stream_order: verify message order when receiving via streams", () => {
+    try {
+      // Group messages by worker
+      const messagesByWorker: string[][] = [];
+
+      // Normalize the collectedMessages structure to match the pull test
+      for (let i = 0; i < collectedMessages.messages.length; i++) {
+        messagesByWorker.push(collectedMessages.messages[i]);
       }
-    });
 
-    afterAll(async () => {
-      try {
-        sendTestResults(hasFailures, testName);
-        await closeEnv(testName, workers);
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
-      }
-    });
+      const stats = calculateMessageStats(
+        messagesByWorker,
+        "gm-",
+        amountofMessages,
+        randomSuffix,
+      );
 
-    it("tc_stream: send the stream", async () => {
-      try {
-        expect(group.id).toBeDefined();
+      // We expect all messages to be received and in order
+      expect(stats.receptionPercentage).toBeGreaterThan(95);
+      expect(stats.orderPercentage).toBeGreaterThan(95);
 
-        // Collect messages by setting up listeners before sending and then sending known messages.
-        collectedMessages = await verifyStream(
-          group,
-          workers.getWorkers(),
-          "text",
-          amountofMessages,
-          (index) => `gm-${index + 1}-${randomSuffix}`,
-        );
-        expect(collectedMessages.allReceived).toBe(true);
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
-      }
-    });
+      sendDeliveryMetric(
+        stats.receptionPercentage,
+        workers.get("bob")!.sdkVersion,
+        workers.get("bob")!.libXmtpVersion,
+        testName,
+        "stream",
+        "delivery",
+      );
+      sendDeliveryMetric(
+        stats.orderPercentage,
+        workers.get("bob")!.sdkVersion,
+        workers.get("bob")!.libXmtpVersion,
+        testName,
+        "stream",
+        "order",
+      );
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
 
-    it("tc_stream_order: verify message order when receiving via streams", () => {
-      try {
-        // Group messages by worker
-        const messagesByWorker: string[][] = [];
+  it("tc_poll_order: verify message order when receiving via pull", async () => {
+    try {
+      const workersFromGroup = await getWorkersFromGroup(group, workers);
+      const messagesByWorker: string[][] = [];
 
-        // Normalize the collectedMessages structure to match the pull test
-        for (let i = 0; i < collectedMessages.messages.length; i++) {
-          messagesByWorker.push(collectedMessages.messages[i]);
-        }
-
-        const stats = calculateMessageStats(
-          messagesByWorker,
-          "gm-",
-          amountofMessages,
-          randomSuffix,
-        );
-
-        // We expect all messages to be received and in order
-        expect(stats.receptionPercentage).toBeGreaterThan(95);
-        expect(stats.orderPercentage).toBeGreaterThan(95);
-
-        sendDeliveryMetric(
-          stats.receptionPercentage,
-          workers.get("bob")!.sdkVersion,
-          workers.get("bob")!.libXmtpVersion,
-          testName,
-          "stream",
-          "delivery",
-        );
-        sendDeliveryMetric(
-          stats.orderPercentage,
-          workers.get("bob")!.sdkVersion,
-          workers.get("bob")!.libXmtpVersion,
-          testName,
-          "stream",
-          "order",
-        );
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
-      }
-    });
-
-    it("tc_poll_order: verify message order when receiving via pull", async () => {
-      try {
-        const workersFromGroup = await getWorkersFromGroup(group, workers);
-        const messagesByWorker: string[][] = [];
-
-        for (const worker of workersFromGroup) {
-          const conversation =
-            await worker.client.conversations.getConversationById(group.id);
-          if (!conversation) {
-            throw new Error("Conversation not found");
-          }
-          const messages = await conversation.messages();
-          const filteredMessages: string[] = [];
-
-          for (const message of messages) {
-            if (
-              message.contentType?.typeId === "text" &&
-              (message.content as string).includes(randomSuffix)
-            ) {
-              filteredMessages.push(message.content as string);
-            }
-          }
-
-          messagesByWorker.push(filteredMessages);
-        }
-
-        const stats = calculateMessageStats(
-          messagesByWorker,
-          "gm-",
-          amountofMessages,
-          randomSuffix,
-        );
-
-        // We expect all messages to be received and in order
-        expect(stats.receptionPercentage).toBeGreaterThan(95);
-        expect(stats.orderPercentage).toBeGreaterThan(95); // At least some workers should have correct order
-
-        sendDeliveryMetric(
-          stats.receptionPercentage,
-          workers.get("bob")!.sdkVersion,
-          workers.get("bob")!.libXmtpVersion,
-          testName,
-          "poll",
-          "delivery",
-        );
-        sendDeliveryMetric(
-          stats.orderPercentage,
-          workers.get("bob")!.sdkVersion,
-          workers.get("bob")!.libXmtpVersion,
-          testName,
-          "poll",
-          "order",
-        );
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
-      }
-    });
-
-    it("tc_offline_recovery: verify message recovery after disconnection", async () => {
-      try {
-        // Select one worker to take offline
-        const offlineWorker = workers.get("bob")!; // Second worker
-        const onlineWorker = workers.get("alice")!; // First worker
-
-        console.log(`Taking ${offlineWorker.name} offline`);
-
-        // Disconnect the selected worker
-        await offlineWorker.worker.terminate();
-
-        // Send messages from an online worker
+      for (const worker of workersFromGroup) {
         const conversation =
-          await onlineWorker.client.conversations.getConversationById(group.id);
-
-        console.log(
-          `Sending ${amountofMessages} messages while client is offline`,
-        );
-        for (let i = 0; i < amountofMessages; i++) {
-          const message = `offline-msg-${i + 1}-${randomSuffix}`;
-          await conversation!.send(message);
+          await worker.client.conversations.getConversationById(group.id);
+        if (!conversation) {
+          throw new Error("Conversation not found");
         }
-        console.log("Sent messages");
+        const messages = await conversation.messages();
+        const filteredMessages: string[] = [];
 
-        // Reconnect the offline worker
-        console.log(`Reconnecting ${offlineWorker.name}`);
-        const { client } = await offlineWorker.worker.initialize();
-        offlineWorker.client = client;
-        await offlineWorker.client.conversations.sync();
-
-        // Verify message recovery
-        const recoveredConversation =
-          await offlineWorker.client.conversations.getConversationById(
-            group.id,
-          );
-        await recoveredConversation?.sync();
-        const messages = await recoveredConversation?.messages();
-
-        const messagesByWorker: string[][] = [];
-        const recoveredMessages: string[] = [];
-        for (const message of messages ?? []) {
+        for (const message of messages) {
           if (
-            message.content &&
-            typeof message.content === "string" &&
-            message.content.includes(`offline-msg-`) &&
-            message.content.includes(randomSuffix)
+            message.contentType?.typeId === "text" &&
+            (message.content as string).includes(randomSuffix)
           ) {
-            recoveredMessages.push(message.content);
+            filteredMessages.push(message.content as string);
           }
         }
 
-        messagesByWorker.push(recoveredMessages);
-
-        const stats = calculateMessageStats(
-          messagesByWorker,
-          "offline-msg-",
-          amountofMessages,
-          randomSuffix,
-        );
-
-        // We expect all messages to be received and in order
-        expect(stats.receptionPercentage).toBeGreaterThan(95);
-        expect(stats.orderPercentage).toBeGreaterThan(95); // At least some workers should have correct order
-
-        sendDeliveryMetric(
-          stats.receptionPercentage,
-          offlineWorker.sdkVersion,
-          offlineWorker.libXmtpVersion,
-          testName,
-          "recovery",
-          "delivery",
-        );
-        sendDeliveryMetric(
-          stats.orderPercentage,
-          offlineWorker.sdkVersion,
-          offlineWorker.libXmtpVersion,
-          testName,
-          "recovery",
-          "order",
-        );
-      } catch (e) {
-        hasFailures = logError(e, expect);
-        throw e;
+        messagesByWorker.push(filteredMessages);
       }
-    });
-  },
-  timeoutMax,
-);
+
+      const stats = calculateMessageStats(
+        messagesByWorker,
+        "gm-",
+        amountofMessages,
+        randomSuffix,
+      );
+
+      // We expect all messages to be received and in order
+      expect(stats.receptionPercentage).toBeGreaterThan(95);
+      expect(stats.orderPercentage).toBeGreaterThan(95); // At least some workers should have correct order
+
+      sendDeliveryMetric(
+        stats.receptionPercentage,
+        workers.get("bob")!.sdkVersion,
+        workers.get("bob")!.libXmtpVersion,
+        testName,
+        "poll",
+        "delivery",
+      );
+      sendDeliveryMetric(
+        stats.orderPercentage,
+        workers.get("bob")!.sdkVersion,
+        workers.get("bob")!.libXmtpVersion,
+        testName,
+        "poll",
+        "order",
+      );
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
+
+  it("tc_offline_recovery: verify message recovery after disconnection", async () => {
+    try {
+      // Select one worker to take offline
+      const offlineWorker = workers.get("bob")!; // Second worker
+      const onlineWorker = workers.get("alice")!; // First worker
+
+      console.log(`Taking ${offlineWorker.name} offline`);
+
+      // Disconnect the selected worker
+      await offlineWorker.worker.terminate();
+
+      // Send messages from an online worker
+      const conversation =
+        await onlineWorker.client.conversations.getConversationById(group.id);
+
+      console.log(
+        `Sending ${amountofMessages} messages while client is offline`,
+      );
+      for (let i = 0; i < amountofMessages; i++) {
+        const message = `offline-msg-${i + 1}-${randomSuffix}`;
+        await conversation!.send(message);
+      }
+      console.log("Sent messages");
+
+      // Reconnect the offline worker
+      console.log(`Reconnecting ${offlineWorker.name}`);
+      const { client } = await offlineWorker.worker.initialize();
+      offlineWorker.client = client;
+      await offlineWorker.client.conversations.sync();
+
+      // Verify message recovery
+      const recoveredConversation =
+        await offlineWorker.client.conversations.getConversationById(group.id);
+      await recoveredConversation?.sync();
+      const messages = await recoveredConversation?.messages();
+
+      const messagesByWorker: string[][] = [];
+      const recoveredMessages: string[] = [];
+      for (const message of messages ?? []) {
+        if (
+          message.content &&
+          typeof message.content === "string" &&
+          message.content.includes(`offline-msg-`) &&
+          message.content.includes(randomSuffix)
+        ) {
+          recoveredMessages.push(message.content);
+        }
+      }
+
+      messagesByWorker.push(recoveredMessages);
+
+      const stats = calculateMessageStats(
+        messagesByWorker,
+        "offline-msg-",
+        amountofMessages,
+        randomSuffix,
+      );
+
+      // We expect all messages to be received and in order
+      expect(stats.receptionPercentage).toBeGreaterThan(95);
+      expect(stats.orderPercentage).toBeGreaterThan(95); // At least some workers should have correct order
+
+      sendDeliveryMetric(
+        stats.receptionPercentage,
+        offlineWorker.sdkVersion,
+        offlineWorker.libXmtpVersion,
+        testName,
+        "recovery",
+        "delivery",
+      );
+      sendDeliveryMetric(
+        stats.orderPercentage,
+        offlineWorker.sdkVersion,
+        offlineWorker.libXmtpVersion,
+        testName,
+        "recovery",
+        "order",
+      );
+    } catch (e) {
+      hasFailures = logError(e, expect);
+      throw e;
+    }
+  });
+});

--- a/suites/TS_Delivery.test.ts
+++ b/suites/TS_Delivery.test.ts
@@ -39,7 +39,6 @@ describe(
         //fs.rmSync(".data", { recursive: true, force: true });
         // Use getWorkers to spin up many workers. This is resource-intensive.
         workers = await getWorkers(receiverAmount, testName);
-        await new Promise((resolve) => setTimeout(resolve, 3000));
         console.log("creating group");
         group = await workers
           .get("bob")!

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -3,6 +3,7 @@ import { sendTestResults } from "@helpers/datadog";
 import generatedInboxes from "@helpers/generated-inboxes.json";
 import { logError } from "@helpers/logger";
 import { XmtpPlaywright } from "@helpers/playwright";
+import { defaultValues } from "@helpers/tests";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -55,7 +56,9 @@ describe(testName, () => {
       // Send a simple message
       const sentMessageId = await convo.send("gm");
       console.log("sentMessageId", sentMessageId);
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await new Promise((resolve) =>
+        setTimeout(resolve, defaultValues.streamTimeout * 2),
+      );
 
       await convo.sync();
       const messagesAfter = await convo.messages();
@@ -64,12 +67,6 @@ describe(testName, () => {
       await convo.sync();
       // We should have at least 2 messages (our message and bot's response)
       expect(messageAfterCount).toBe(prevMessageCount + 2);
-      console.log(
-        "Messages before:",
-        prevMessageCount,
-        "after:",
-        messageAfterCount,
-      );
     } catch (e) {
       hasFailures = logError(e, expect);
       throw e;

--- a/suites/TS_Gm.test.ts
+++ b/suites/TS_Gm.test.ts
@@ -57,7 +57,7 @@ describe(testName, () => {
       const sentMessageId = await convo.send("gm");
       console.log("sentMessageId", sentMessageId);
       await new Promise((resolve) =>
-        setTimeout(resolve, defaultValues.streamTimeout * 2),
+        setTimeout(resolve, defaultValues.streamTimeout),
       );
 
       await convo.sync();


### PR DESCRIPTION
### Increase stream timeout from 1000ms to 3000ms and standardize message sync delays across test suites
* Increases `defaultValues.streamTimeout` from 1000ms to 3000ms in [tests.ts](https://github.com/xmtp/xmtp-qa-testing/pull/172/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626)
* Removes inter-message delays in `verifyStream` function and adds initialization delay in `createGroup` function in [streams.ts](https://github.com/xmtp/xmtp-qa-testing/pull/172/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a)
* Removes dynamic timeout calculations and fixed delays in [TS_Delivery.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/172/files#diff-70abff779aee585192310614e0879e0cef36ca92d27f88c125a884106720b92c)
* Updates message send delay in [TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/172/files#diff-8926b702250dc4b4d7dfcaab5ae0f36b1d2013a5f02457d8df22d2643a646c06) to use `defaultValues.streamTimeout`

#### 📍Where to Start
Start with the `defaultValues` object in [tests.ts](https://github.com/xmtp/xmtp-qa-testing/pull/172/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626) which defines the new standardized timeout value used across the test suites.

----

_[Macroscope](https://app.macroscope.com) summarized 72b2c73._