### PR TITLE
Update worker log to show address instead of inboxId

### DIFF
--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -311,7 +311,7 @@ const startGPTWorkers = async () => {
   );
   console.log("GPT workers:", workersGpt.getWorkers().length);
   for (const worker of workersGpt.getWorkers()) {
-    console.log("GPT workers:", worker.name, worker.inboxId);
+    console.log("GPT workers:", worker.name, worker.address);
   }
 };
 

--- a/helpers/groups.ts
+++ b/helpers/groups.ts
@@ -98,18 +98,41 @@ export async function createAndSendInGroup(
     const allInboxIds = workers.getWorkers().map((w) => w.client.inboxId);
     allInboxIds.push(receiverInboxId);
 
-    for (let i = 0; i < groupCount; i++) {
-      const groupName = `Test Group ${i} ${allInboxIds.length}`;
-      const group = await client.conversations.newGroup(allInboxIds, {
-        groupName,
-        groupDescription: "Test group for stress testing",
-      });
+    console.log(
+      `Creating ${groupCount} groups with ${allInboxIds.length} members in each`,
+    );
 
-      await group.send(`Hello from the group! ${i}`);
+    for (let i = 0; i < groupCount; i++) {
+      try {
+        const groupName = `Test Group ${i} ${allInboxIds.length}`;
+        console.log(
+          `Creating group "${groupName}" with ${allInboxIds.length} members...`,
+        );
+
+        const group = await client.conversations.newGroup(allInboxIds, {
+          groupName,
+          groupDescription: "Test group for stress testing",
+        });
+
+        console.log(`Successfully created group: ${group.id}`);
+        console.log(`Sending message to group ${group.id}...`);
+
+        await group.send(`Hello from the group! ${i}`);
+        console.log(`Message successfully sent to group ${group.id}`);
+      } catch (groupError) {
+        console.error(
+          `Error creating/messaging group ${i}:`,
+          groupError instanceof Error ? groupError.message : String(groupError),
+        );
+        // Continue with the next group instead of stopping completely
+      }
     }
     return true;
   } catch (error) {
-    console.error(error);
+    console.error(
+      "Error in createAndSendInGroup:",
+      error instanceof Error ? error.message : String(error),
+    );
     throw error;
   }
 }


### PR DESCRIPTION
### Update worker logging to display address instead of inboxId to improve log readability in stress testing bot
* Implements continuous retry loop in `startGPTWorkers` and message stream handling in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/177/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f) to prevent application crashes
* Adds environment variable checks for `OPENAI_API_KEY` and `SKIP_GPT_WORKERS` in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/177/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f)
* Enhances error handling in `createAndSendInGroup` function within [helpers/groups.ts](https://github.com/xmtp/xmtp-qa-testing/pull/177/files#diff-a2cc8e0f2de986c788eaf8dae487932cca014dc8c0162bdc6e74f756c77bd6aa) to continue group creation on individual failures
* Modifies `WorkerClient` class in [workers/main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/177/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) to restart message streams on errors and filter non-text messages

#### 📍Where to Start
Start with the `startGPTWorkers` function in [bots/stress/index.ts](https://github.com/xmtp/xmtp-qa-testing/pull/177/files#diff-3694bc221de40b8821ca88fc09b9d5e4ab52baef2cac56ce0f3fb4d1d6a6252f) which contains the core changes to worker initialization and error handling.

----

_[Macroscope](https://app.macroscope.com) summarized 2fb8e8c._