### PR TITLE
Update README links for agent health and fork tests

### DIFF
--- a/suites/TS_AgentHealth/README.md
+++ b/suites/TS_AgentHealth/README.md
@@ -2,6 +2,8 @@
 
 This test suite validates the health and responsiveness of live XMTP agents in production environments.
 
+https://github.com/user-attachments/assets/bbe94427-8fcb-463c-98fb-6417c16dd4cf
+
 ## Test Environment
 
 - **Client**: Single worker "bob" for interaction with various agents

--- a/suites/TS_Fork/README.md
+++ b/suites/TS_Fork/README.md
@@ -2,7 +2,7 @@
 
 This test suite reproduces group conversation forking issues in XMTP by simulating high-frequency membership changes and message exchanges.
 
-![Fork Testing Visualization](https://github.com/user-attachments/assets/e4842b28-e1c4-4a6c-87ac-2e11651b2939)
+https://github.com/user-attachments/assets/e4842b28-e1c4-4a6c-87ac-2e11651b2939
 
 ## Test Environment
 

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -73,7 +73,7 @@ describe(testName, () => {
       const xmtpTester = new XmtpPlaywright(false);
       const result = await xmtpTester.newDmWithDeeplink(
         gmBotAddress,
-        "gm",
+        "hi",
         "gm",
       );
       expect(result).toBe(true);


### PR DESCRIPTION
### Update documentation links for agent health and fork test visualizations in test suite README files
* Add GitHub user attachment URL for visualization in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/201/files#diff-b056ea64bd4725c21b3d759393b0e72dcf90d9bee92d42e9b473f6fb274c9139)
* Modify image reference format from Markdown to plain URL in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/201/files#diff-e6bc3996f4527fcdffe252a7e8096e77d3431d1d16b54c0b13bc35455aee9a16)

#### 📍Where to Start
Start with the [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/201/files#diff-b056ea64bd4725c21b3d759393b0e72dcf90d9bee92d42e9b473f6fb274c9139) in the agent health test suite directory, followed by the fork test suite [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/201/files#diff-e6bc3996f4527fcdffe252a7e8096e77d3431d1d16b54c0b13bc35455aee9a16).

----

_[Macroscope](https://app.macroscope.com) summarized 9b997e6._