### PR TITLE
Refactor tests to run all agents for local testing

### DIFF
--- a/.github/workflows/TS_AgentHealth.yml
+++ b/.github/workflows/TS_AgentHealth.yml
@@ -1,56 +1,33 @@
 name: TS_AgentHealth
-description: "should verify health of live agents"
+description: "should verify health of agents"
 
 on:
   schedule:
-    - cron: "*/30 * * * *" # Runs every 30 minutes
+    - cron: "15,45 * * * *" # Runs at 15 and 45 minutes past each hour
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
-  get-agents-and-networks:
-    runs-on: ubuntu-latest
-    outputs:
-      agent-network-pairs: ${{ steps.set-matrix.outputs.agent-network-pairs }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set matrix
-        id: set-matrix
-        run: |
-          # Read the agents.json file
-          AGENTS=$(cat suites/TS_AgentHealth/agents.json)
-
-          # Create an array of agent-network pairs for the matrix
-          # Add a display_name field for GitHub Actions matrix display
-          pairs=$(echo $AGENTS | jq -c '[.[] | .networks[] as $network | {name: .name, address: .address, network: $network, display_name: (.name + " (" + $network + ")")}]') 
-
-          # Set the output for the matrix
-          echo "agent-network-pairs=$(echo $pairs)" >> $GITHUB_OUTPUT
-          echo "Found agent-network pairs: $pairs"
-
   test:
-    needs: get-agents-and-networks
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        agent-network: ${{ fromJson(needs.get-agents-and-networks.outputs.agent-network-pairs) }}
-    name: ${{ matrix.agent-network.display_name }}
+        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}
-      XMTP_ENV: ${{ matrix.agent-network.network }}
+      XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
       GM_BOT_ADDRESS: ${{ vars.GM_BOT_ADDRESS }}
       WALLET_KEY_XMTP_CHAT: ${{ secrets.WALLET_KEY_XMTP_CHAT }}
       ENCRYPTION_KEY_XMTP_CHAT: ${{ secrets.ENCRYPTION_KEY_XMTP_CHAT }}
-      TARGET_AGENT_NAME: ${{ matrix.agent-network.name }}
-      TARGET_AGENT_ADDRESS: ${{ matrix.agent-network.address }}
     steps:
       - uses: actions/checkout@v4
-      - name: Debug info
+      - name: Debug API key
         run: |
-          echo "Testing agent: ${{ matrix.agent-network.name }} on network: ${{ matrix.agent-network.network }}"
           if [ -n "${{ secrets.DATADOG_API_KEY }}" ]; then
             echo "API key is available in test job"
           else
@@ -72,6 +49,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.agent-network.name }}_${{ matrix.agent-network.network }}
+          name: ts_agenthealth_${{ matrix.environment }}
           path: |
             logs/
+            logs/**/*.png

--- a/.github/workflows/TS_AgentHealth.yml
+++ b/.github/workflows/TS_AgentHealth.yml
@@ -13,13 +13,9 @@ jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}
-      XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
       GM_BOT_ADDRESS: ${{ vars.GM_BOT_ADDRESS }}
       WALLET_KEY_XMTP_CHAT: ${{ secrets.WALLET_KEY_XMTP_CHAT }}

--- a/.github/workflows/TS_AgentHealth.yml
+++ b/.github/workflows/TS_AgentHealth.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "15,45 * * * *" # Runs at 15 and 45 minutes past each hour
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/suites/TS_AgentHealth/TS_AgentHealth.test.ts
+++ b/suites/TS_AgentHealth/TS_AgentHealth.test.ts
@@ -22,9 +22,6 @@ const typedAgents = agentHealth as Agent[];
 const testName = "ts_agenthealth";
 loadEnv(testName);
 
-const targetAgentName = process.env.TARGET_AGENT_NAME;
-const targetAgentAddress = process.env.TARGET_AGENT_ADDRESS;
-
 describe(testName, () => {
   let hasFailures = false;
   let workers: WorkerManager | undefined;
@@ -37,17 +34,9 @@ describe(testName, () => {
       throw e;
     }
   });
-  // If specific agent is targeted by CI matrix
-  if (targetAgentName && targetAgentAddress) {
-    const agent = typedAgents.find(
-      (a) => a.name === targetAgentName && a.address === targetAgentAddress,
-    );
 
-    if (!agent) {
-      throw new Error(
-        `Agent ${targetAgentName} (${targetAgentAddress}) not found in agents list`,
-      );
-    }
+  // For local testing, test all agents on their supported networks
+  for (const agent of typedAgents) {
     for (const network of agent.networks) {
       it(`${agent.name} ${network}`, async () => {
         try {
@@ -64,27 +53,6 @@ describe(testName, () => {
           throw e;
         }
       });
-    }
-  } else {
-    // For local testing, test all agents on their supported networks
-    for (const agent of typedAgents) {
-      for (const network of agent.networks) {
-        it(`${agent.name} ${network}`, async () => {
-          try {
-            console.log(`Testing ${agent.name} on ${network}`);
-            const xmtpTester = new XmtpPlaywright(true, network as XmtpEnv);
-            const result = await xmtpTester.newDmWithDeeplink(
-              agent.address,
-              agent.sendMessage,
-              agent.expectedMessage,
-            );
-            expect(result).toBe(true);
-          } catch (e) {
-            logError(e, expect);
-            throw e;
-          }
-        });
-      }
     }
   }
 });

--- a/suites/TS_AgentHealth/agents.json
+++ b/suites/TS_AgentHealth/agents.json
@@ -6,14 +6,6 @@
     "sendMessage": "hola",
     "expectedMessage": "chat"
   },
-
-  {
-    "name": "xmtp-gang-concierge",
-    "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
-    "networks": ["dev", "production"],
-    "sendMessage": "hola",
-    "expectedMessage": "chat"
-  },
   {
     "name": "gm-bot",
     "address": "0x20b572be48527a770479744aec6fe5644f97678b",

--- a/suites/TS_AgentHealth/others.json
+++ b/suites/TS_AgentHealth/others.json
@@ -1,10 +1,10 @@
 [
   {
-    "name": "key-check.eth",
-    "address": "0x235017975ed5F55e23a71979697Cd67DcAE614Fa",
-    "networks": ["production"],
-    "sendMessage": "/kc",
-    "expectedMessage": "Key Check"
+    "name": "xmtp-gang-concierge",
+    "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
+    "networks": ["dev", "production"],
+    "sendMessage": "hola",
+    "expectedMessage": "chat"
   },
   {
     "name": "bankr.base.eth",


### PR DESCRIPTION
### Modify agent health workflow to run tests for all agents locally by removing matrix-based execution and updating test scheduling to run at 15 and 45 minutes past each hour
The agent health testing infrastructure is restructured across multiple files:

* [TS_AgentHealth.yml](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-fa5226b9e45154a8355cbaf85933a4bed1969c8c8918d27c7a0b2351a2621aae) workflow now runs a single test job instead of using a matrix strategy, with tests executing at 15 and 45 minutes past each hour
* [TS_AgentHealth.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-f36359b669c17536f82556d885a12694bac14d5f212a01b48670034e9cc354c9) removes conditional logic for targeted agent testing, now testing all agents on supported networks
* [agents.json](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-9fff9a9b7894e4b65b380f3a5c6c547454bf1d4cf0316909c56be329f8519261) and [others.json](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-69c03e560aa4bfdcd1cf8fa136740448b7472bca5ba54b9aede81e4a013e2a47) reorganize agent configurations, moving `xmtp-gang-concierge` agent to a separate file

#### 📍Where to Start
Start with the workflow definition in [TS_AgentHealth.yml](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-fa5226b9e45154a8355cbaf85933a4bed1969c8c8918d27c7a0b2351a2621aae) which defines the new test execution structure, then move to [TS_AgentHealth.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/206/files#diff-f36359b669c17536f82556d885a12694bac14d5f212a01b48670034e9cc354c9) to understand the simplified test implementation.

----

_[Macroscope](https://app.macroscope.com) summarized 4b2a179._