### PR TITLE
Add default user option for improved testing flexibility

### DIFF
--- a/functional/browser.test.ts
+++ b/functional/browser.test.ts
@@ -9,6 +9,7 @@ loadEnv(testName);
 
 describe(testName, () => {
   // Check if GM_BOT_ADDRESS environment variable is set
+  const xmtpTester = new XmtpPlaywright(true, "dev");
   const gmBotAddress = process.env.GM_BOT_ADDRESS;
 
   it("should respond to a message", async () => {
@@ -18,7 +19,6 @@ describe(testName, () => {
         throw new Error("GM_BOT_ADDRESS environment variable is not set");
       }
 
-      const xmtpTester = new XmtpPlaywright(true, "production");
       const result = await xmtpTester.newDmWithDeeplink(
         gmBotAddress,
         "hi",
@@ -37,7 +37,6 @@ describe(testName, () => {
         throw new Error("GM_BOT_ADDRESS environment variable is not set");
       }
 
-      const xmtpTester = new XmtpPlaywright(true, "production");
       const slicedInboxes = generatedInboxes.slice(0, 4);
       await xmtpTester.createGroupAndReceiveGm([
         ...slicedInboxes.map((inbox) => inbox.accountAddress),

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -131,6 +131,9 @@ export class XmtpPlaywright {
       console.log("Filling message");
       await page
         .getByRole("textbox", { name: "Type a message..." })
+        .waitFor({ state: "visible" });
+      await page
+        .getByRole("textbox", { name: "Type a message..." })
         .fill(sendMessage);
       console.log("Sending message");
       await page.getByRole("button", { name: "Send" }).click();
@@ -210,11 +213,13 @@ export class XmtpPlaywright {
     walletKey: string = "",
     walletEncryptionKey: string = "",
   ): Promise<void> {
-    console.log(
-      "Setting localStorage",
-      walletKey.slice(0, 4),
-      walletEncryptionKey.slice(0, 4),
-    );
+    if (this.defaultUser) {
+      console.log(
+        "Setting localStorage",
+        walletKey.slice(0, 4) + "...",
+        walletEncryptionKey.slice(0, 4) + "...",
+      );
+    }
     await page.addInitScript(
       ({ envValue, walletKey, walletEncryptionKey }) => {
         if (walletKey !== "") console.log("Setting walletKey", walletKey);
@@ -306,8 +311,10 @@ export class XmtpPlaywright {
       }
       return false;
     } catch (error) {
-      console.error("Error in sendAndWaitForResponse:", error);
+      console.error("Error in sendPassPhrase:", error);
       return false;
+    } finally {
+      if (browser) await browser.close();
     }
   }
 }

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -205,15 +205,17 @@ export class XmtpPlaywright {
   ): Promise<void> {
     await page.addInitScript(
       ({ envValue, walletKey, walletEncryptionKey }) => {
-        if (walletKey !== "")
-          // @ts-expect-error Window localStorage access in browser context
-          window.localStorage.setItem("XMTP_EPHEMERAL_ACCOUNT_KEY", walletKey);
-        if (walletEncryptionKey !== "")
+        if (walletKey !== "") console.log("Setting walletKey", walletKey);
+        // @ts-expect-error Window localStorage access in browser context
+        window.localStorage.setItem("XMTP_EPHEMERAL_ACCOUNT_KEY", walletKey);
+        if (walletEncryptionKey !== "") {
+          console.log("Setting walletEncryptionKey", walletEncryptionKey);
           // @ts-expect-error Window localStorage access in browser context
           window.localStorage.setItem(
             "XMTP_ENCRYPTION_KEY",
             walletEncryptionKey,
           );
+        }
         // @ts-expect-error Window localStorage access in browser context
         window.localStorage.setItem("XMTP_NETWORK", envValue);
         // @ts-expect-error Window localStorage access in browser context

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -16,7 +16,12 @@ export class XmtpPlaywright {
   private env: XmtpEnv = "local";
   private walletKey: string = "";
   private encryptionKey: string = "";
-  constructor(headless: boolean = true, env: XmtpEnv | null = null) {
+  private defaultUser: boolean = false;
+  constructor(
+    headless: boolean = true,
+    env: XmtpEnv | null = null,
+    defaultUser: boolean = false,
+  ) {
     this.isHeadless =
       process.env.GITHUB_ACTIONS !== undefined ? true : headless;
     this.env = env ?? (process.env.XMTP_ENV as XmtpEnv);
@@ -24,13 +29,14 @@ export class XmtpPlaywright {
     this.encryptionKey = process.env.ENCRYPTION_KEY_XMTP_CHAT as string;
     this.browser = null;
     this.page = null;
+    this.defaultUser = defaultUser;
   }
 
   /**
    * Creates a group and checks for GM response
    */
   async createGroupAndReceiveGm(addresses: string[]): Promise<void> {
-    const { page, browser } = await this.startPage(false);
+    const { page, browser } = await this.startPage();
     try {
       console.log("Filling addresses and creating group");
       await this.fillAddressesAndCreate(page, addresses);
@@ -51,7 +57,7 @@ export class XmtpPlaywright {
     groupId: string,
     messages: string[],
   ): Promise<boolean> {
-    const { page, browser } = await this.startPage(false);
+    const { page, browser } = await this.startPage();
     try {
       await page.goto(`https://xmtp.chat/group/${groupId}?env=${this.env}`);
       await this.takeSnapshot(page, "before-reading-group-messages");
@@ -153,8 +159,7 @@ export class XmtpPlaywright {
    * Starts a new page with the specified options
    */
   private async startPage(
-    defaultUser: boolean = false,
-    address: string = "",
+    address?: string,
   ): Promise<{ browser: Browser; page: Page }> {
     this.browser = await chromium.launch({
       headless: this.isHeadless,
@@ -174,8 +179,8 @@ export class XmtpPlaywright {
 
     await this.setLocalStorage(
       this.page,
-      defaultUser ? this.walletKey : "",
-      defaultUser ? this.encryptionKey : "",
+      this.defaultUser ? this.walletKey : "",
+      this.defaultUser ? this.encryptionKey : "",
     );
 
     let url = "https://xmtp.chat/";
@@ -230,7 +235,7 @@ export class XmtpPlaywright {
     sendMessage: string,
     expectedMessage: string,
   ): Promise<boolean> {
-    const { page, browser } = await this.startPage(false, address);
+    const { page, browser } = await this.startPage(address);
     try {
       return await this.sendAndWaitForResponse(
         page,
@@ -243,6 +248,52 @@ export class XmtpPlaywright {
       return false;
     } finally {
       if (browser) await browser.close();
+    }
+  }
+
+  /**
+   * Sends a message and optionally waits for GM response
+   */
+  public async sendPassPhrase(
+    address: string,
+    sendMessage: string,
+    expectedMessage: string,
+    passPhrase: string,
+  ): Promise<boolean> {
+    const { page, browser } = await this.startPage(address);
+    try {
+      await page.getByRole("textbox", { name: "Type a message..." }).click();
+      await page
+        .getByRole("textbox", { name: "Type a message..." })
+        .fill(sendMessage);
+      await page.getByRole("button", { name: "Send" }).click();
+      const hiMessage = await page.getByText(sendMessage);
+      const hiMessageText = await hiMessage.textContent();
+      console.log("Sent message:", hiMessageText?.toLowerCase());
+
+      const botMessageLocator = page.getByText(expectedMessage);
+      await botMessageLocator.waitFor({
+        state: "visible",
+        timeout: defaultValues.streamTimeout,
+      });
+      const botMessageText = await botMessageLocator.textContent();
+      console.log("Received message:", botMessageText?.toLowerCase());
+      if (
+        botMessageText?.toLowerCase().includes(expectedMessage.toLowerCase())
+      ) {
+        await page.getByRole("textbox", { name: "Type a message..." }).click();
+        await page
+          .getByRole("textbox", { name: "Type a message..." })
+          .fill(passPhrase);
+        await page.getByRole("button", { name: "Send" }).click();
+        const hiMessage = await page.getByText(passPhrase);
+        const hiMessageText = await hiMessage.textContent();
+        console.log("Sent message:", hiMessageText?.toLowerCase());
+      }
+      return false;
+    } catch (error) {
+      console.error("Error in sendAndWaitForResponse:", error);
+      return false;
     }
   }
 }

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -124,10 +124,15 @@ export class XmtpPlaywright {
     expectedMessage: string,
   ): Promise<boolean> {
     try {
-      await page.getByRole("textbox", { name: "Type a message..." }).click();
+      console.log("Waiting for message input to be visible");
+      await page
+        .getByRole("textbox", { name: "Type a message..." })
+        .waitFor({ state: "visible" });
+      console.log("Filling message");
       await page
         .getByRole("textbox", { name: "Type a message..." })
         .fill(sendMessage);
+      console.log("Sending message");
       await page.getByRole("button", { name: "Send" }).click();
       const hiMessage = await page.getByText(sendMessage);
       const hiMessageText = await hiMessage.textContent();
@@ -190,7 +195,9 @@ export class XmtpPlaywright {
     console.log("Navigating to:", url);
     await this.page.goto(url);
     await this.page.waitForTimeout(1000);
-    await this.page.getByText("Ephemeral", { exact: true }).click();
+    if (!this.defaultUser) {
+      await this.page.getByText("Ephemeral", { exact: true }).click();
+    }
 
     return { browser: this.browser, page: this.page };
   }
@@ -203,6 +210,11 @@ export class XmtpPlaywright {
     walletKey: string = "",
     walletEncryptionKey: string = "",
   ): Promise<void> {
+    console.log(
+      "Setting localStorage",
+      walletKey.slice(0, 4),
+      walletEncryptionKey.slice(0, 4),
+    );
     await page.addInitScript(
       ({ envValue, walletKey, walletEncryptionKey }) => {
         if (walletKey !== "") console.log("Setting walletKey", walletKey);

--- a/suites/TS_Farcon/TS_Farcon.test.ts
+++ b/suites/TS_Farcon/TS_Farcon.test.ts
@@ -16,11 +16,11 @@ describe(testName, () => {
         throw new Error("GM_BOT_ADDRESS environment variable is not set");
       }
 
-      const xmtpTester = new XmtpPlaywright(false, "dev", true);
+      const xmtpTester = new XmtpPlaywright(false, "production", true);
       const result = await xmtpTester.newDmWithDeeplink(
         gmBotAddress,
         "hi",
-        "passphrase",
+        "added",
         //"You've been added to the Farcon group. Check your message requests in your inbox to view",
       );
       expect(result).toBe(true);

--- a/suites/TS_Farcon/TS_Farcon.test.ts
+++ b/suites/TS_Farcon/TS_Farcon.test.ts
@@ -16,11 +16,12 @@ describe(testName, () => {
         throw new Error("GM_BOT_ADDRESS environment variable is not set");
       }
 
-      const xmtpTester = new XmtpPlaywright(true, "dev", true);
+      const xmtpTester = new XmtpPlaywright(false, "dev", true);
       const result = await xmtpTester.newDmWithDeeplink(
         gmBotAddress,
         "hi",
-        "You've been added to the Farcon group. Check your message requests in your inbox to view",
+        "passphrase",
+        //"You've been added to the Farcon group. Check your message requests in your inbox to view",
       );
       expect(result).toBe(true);
     } catch (error) {

--- a/suites/TS_Farcon/TS_Farcon.test.ts
+++ b/suites/TS_Farcon/TS_Farcon.test.ts
@@ -1,0 +1,31 @@
+import { loadEnv } from "@helpers/client";
+import { XmtpPlaywright } from "@helpers/playwright";
+import { describe, expect, it } from "vitest";
+
+const testName = "browser";
+loadEnv(testName);
+
+describe(testName, () => {
+  // Check if GM_BOT_ADDRESS environment variable is set
+  const gmBotAddress = "0xD75FaA8A834570b4df073500F31E3103227299ed";
+
+  it("should respond to a message", async () => {
+    console.log("sending gm to bot", gmBotAddress);
+    try {
+      if (!gmBotAddress) {
+        throw new Error("GM_BOT_ADDRESS environment variable is not set");
+      }
+
+      const xmtpTester = new XmtpPlaywright(true, "dev", true);
+      const result = await xmtpTester.newDmWithDeeplink(
+        gmBotAddress,
+        "hi",
+        "You've been added to the Farcon group. Check your message requests in your inbox to view",
+      );
+      expect(result).toBe(true);
+    } catch (error) {
+      console.error("Error in browser test:", error);
+      throw error;
+    }
+  });
+});

--- a/suites/TS_Notifications/TS_Notifications.test.ts
+++ b/suites/TS_Notifications/TS_Notifications.test.ts
@@ -20,8 +20,11 @@ describe(testName, () => {
   // Number of messages to send
   const NUM_MESSAGES = 10;
   // Target worker (receiver)
-  const receiverInboxId =
+  const addFabri =
+    "705c87a99e87097ee2044aec0bdb4617634e015db73900453ad56a7da80157ff";
+  const convosId =
     "c10e8c13c833f1826e98fb0185403c2c4d5737cc432d575468613abf9adae26b";
+  const receiverInboxId = addFabri;
   // Sender workers
   const SENDER_WORKERS = ["alice", "bob", "sam", "walt", "tina"];
 


### PR DESCRIPTION
### Add defaultUser parameter to XmtpPlaywright class and configure test environments for improved testing flexibility
* Adds `defaultUser` parameter to `XmtpPlaywright` class in [helpers/playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) with associated error handling, debugging logs, and UI element visibility checks
* Introduces new `sendPassPhrase` method for authentication workflows in [helpers/playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e)
* Creates new Farcon test suite in [suites/TS_Farcon/TS_Farcon.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-1772b08b31b2c62e5b51adb25e4a35bbfa029831af54509f0603500b2e313766) to verify bot messaging functionality
* Refactors browser tests in [functional/browser.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-1d25a458583d9b10d12d8961e4ce06c9b250d755b459635f57e07c5966cff6cb) to use 'dev' environment and top-level initialization
* Updates notification test receiver IDs in [suites/TS_Notifications/TS_Notifications.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-fcb5b4535388467a4f206cd080be0ab8e3dcb3f1786bd52df6b3f7e1316516e9)

#### 📍Where to Start
Start with the `XmtpPlaywright` class modifications in [helpers/playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/209/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) which contains the core changes to the testing framework.

----

_[Macroscope](https://app.macroscope.com) summarized ede90fd._