### PR TITLE
Remove unused variable for cleaner code clarity

### DIFF
--- a/functional/browser.test.ts
+++ b/functional/browser.test.ts
@@ -9,7 +9,10 @@ loadEnv(testName);
 
 describe(testName, () => {
   // Check if GM_BOT_ADDRESS environment variable is set
-  const xmtpTester = new XmtpPlaywright(true, "production");
+  const xmtpTester = new XmtpPlaywright({
+    headless: true,
+    env: "production",
+  });
   const gmBotAddress = process.env.GM_BOT_ADDRESS;
 
   it("should respond to a message", async () => {

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -143,9 +143,6 @@ const xmtpPlaywright = new XmtpPlaywright(headless, env);
 
 // Create a group and check for response
 await xmtpPlaywright.createGroupAndReceiveGm(addresses);
-
-// Read messages in a group
-const success = await xmtpPlaywright.readGroupMessages(groupId, messages);
 ```
 
 **Key features:**

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -9,42 +9,58 @@ import {
 } from "playwright-chromium";
 import { defaultValues } from "./tests";
 
+type BrowserSession = {
+  browser: Browser;
+  page: Page;
+};
+
+interface XmtpPlaywrightOptions {
+  headless?: boolean;
+  env?: XmtpEnv | null;
+  defaultUser?: boolean;
+}
+
 export class XmtpPlaywright {
   private browser: Browser | null = null;
   private page: Page | null = null;
-  private isHeadless: boolean = true;
-  private env: XmtpEnv = "local";
-  private walletKey: string = "";
-  private encryptionKey: string = "";
-  private defaultUser: boolean = false;
+  private readonly isHeadless: boolean;
+  private readonly env: XmtpEnv;
+  private readonly walletKey: string;
+  private readonly encryptionKey: string;
+  private readonly defaultUser: boolean;
+
   constructor(
-    headless: boolean = true,
-    env: XmtpEnv | null = null,
-    defaultUser: boolean = false,
+    {
+      headless = true,
+      env = null,
+      defaultUser = false,
+    }: XmtpPlaywrightOptions = {
+      headless: true,
+      env: null,
+      defaultUser: false,
+    },
   ) {
     this.isHeadless =
       process.env.GITHUB_ACTIONS !== undefined ? true : headless;
     this.env = env ?? (process.env.XMTP_ENV as XmtpEnv);
+    console.log("Starting XmtpPlaywright with env:", this.env);
     this.walletKey = process.env.WALLET_KEY_XMTP_CHAT as string;
     this.encryptionKey = process.env.ENCRYPTION_KEY_XMTP_CHAT as string;
-    this.browser = null;
-    this.page = null;
     this.defaultUser = defaultUser;
   }
 
   /**
-   * Creates a group and checks for GM response
+   * Creates a group, adds the provided addresses, and tests for an expected response
    */
   async createGroupAndReceiveGm(
     addresses: string[],
     expectedResponse?: string | string[],
   ): Promise<void> {
-    const { page, browser } = await this.startPage();
+    const session = await this.startPage();
     try {
-      console.log("Filling addresses and creating group");
-      await this.fillAddressesAndCreate(page, addresses);
+      await this.fillAddressesAndCreate(session.page, addresses);
       const response = await this.sendAndWaitForResponse(
-        page,
+        session.page,
         "hi",
         expectedResponse || "gm",
       );
@@ -53,10 +69,34 @@ export class XmtpPlaywright {
       }
     } catch (error) {
       console.error("Error in createGroupAndReceiveGm:", error);
-      await this.takeSnapshot(page, "before-finding-gm");
+      await this.takeSnapshot(session.page, "before-finding-gm");
       throw error;
     } finally {
-      if (browser) await browser.close();
+      await this.closeBrowser(session.browser);
+    }
+  }
+
+  /**
+   * Tests a DM with an agent using deeplink
+   */
+  async newDmWithDeeplink(
+    address: string,
+    sendMessage: string,
+    expectedMessage?: string | string[],
+  ): Promise<boolean> {
+    const session = await this.startPage(address);
+    try {
+      return await this.sendAndWaitForResponse(
+        session.page,
+        sendMessage,
+        expectedMessage,
+      );
+    } catch (error) {
+      console.error("Could not find expected message:", error);
+      await this.takeSnapshot(session.page, "before-finding-expected-message");
+      return false;
+    } finally {
+      await this.closeBrowser(session.browser);
     }
   }
 
@@ -90,6 +130,7 @@ export class XmtpPlaywright {
       .getByRole("button", { name: "Create a new group" })
       .click();
     await page.getByRole("button", { name: "Members" }).click();
+
     for (const address of addresses) {
       await page.getByRole("textbox", { name: "Address" }).fill(address);
       await page.getByRole("button", { name: "Add" }).click();
@@ -107,96 +148,8 @@ export class XmtpPlaywright {
     expectedMessage?: string | string[],
   ): Promise<boolean> {
     try {
-      console.log("Waiting for message input to be visible");
-      await page
-        .getByRole("textbox", { name: "Type a message..." })
-        .waitFor({ state: "visible" });
-      console.log("Filling message");
-      await page
-        .getByRole("textbox", { name: "Type a message..." })
-        .fill(sendMessage);
-      console.log("Sending message", sendMessage);
-      await page.waitForTimeout(1000);
-      await page.getByRole("button", { name: "Send" }).click();
-
-      // Wait for messages to appear in the virtuoso list
-      await page.waitForSelector(
-        'div[data-testid="virtuoso-item-list"] > div',
-        {
-          timeout: defaultValues.streamTimeout,
-        },
-      );
-
-      // Get initial message count
-      const initialMessageCount = await page
-        .locator('div[data-testid="virtuoso-item-list"] > div')
-        .count();
-      console.log(`Initial message count: ${initialMessageCount}`);
-
-      // Wait for new message to appear
-      let messageFound = false;
-      let responseText = "";
-
-      // Convert expected message to array for consistent handling
-      const expectedPhrases = expectedMessage
-        ? Array.isArray(expectedMessage)
-          ? expectedMessage
-          : [expectedMessage]
-        : [];
-
-      // Poll for new messages
-      for (let i = 0; i < 30; i++) {
-        await page.waitForTimeout(1000);
-        const currentMessageCount = await page
-          .locator('div[data-testid="virtuoso-item-list"] > div')
-          .count();
-
-        if (currentMessageCount > initialMessageCount) {
-          // Get the latest message
-          const messageItems = await page
-            .locator('div[data-testid="virtuoso-item-list"] > div')
-            .all();
-          const latestMessageElement = messageItems[messageItems.length - 1];
-
-          responseText = (await latestMessageElement.textContent()) || "";
-          console.log(`Latest message: "${responseText}"`);
-
-          if (!expectedPhrases.length) {
-            // If no expected message, any response is valid
-            messageFound = true;
-            break;
-          } else {
-            // Check if any of the expected phrases are in the response
-            messageFound = expectedPhrases.some((phrase) =>
-              responseText.toLowerCase().includes(phrase.toLowerCase()),
-            );
-
-            if (messageFound) break;
-          }
-        }
-      }
-
-      if (messageFound) {
-        if (expectedPhrases.length) {
-          console.log(
-            `Found expected response containing one of [${expectedPhrases.join(", ")}]: "${responseText}"`,
-          );
-        } else {
-          console.log(`Received a response: "${responseText}"`);
-        }
-      } else {
-        if (expectedPhrases.length) {
-          console.log(
-            `Failed to find response containing any of [${expectedPhrases.join(", ")}]. Last message: "${responseText}"`,
-          );
-        } else {
-          console.log(
-            `Failed to receive any response. Last message: "${responseText}"`,
-          );
-        }
-      }
-
-      return messageFound;
+      await this.sendMessage(page, sendMessage);
+      return await this.waitForResponse(page, expectedMessage);
     } catch (error) {
       console.error("Error in sendAndWaitForResponse:", error);
       await this.takeSnapshot(page, "before-finding-expected-message");
@@ -205,40 +158,139 @@ export class XmtpPlaywright {
   }
 
   /**
+   * Sends a message in the current conversation
+   */
+  private async sendMessage(page: Page, message: string): Promise<void> {
+    console.log("Waiting for message input to be visible");
+    await page
+      .getByRole("textbox", { name: "Type a message..." })
+      .waitFor({ state: "visible" });
+
+    console.log("Filling message");
+    await page
+      .getByRole("textbox", { name: "Type a message..." })
+      .fill(message);
+
+    console.log("Sending message", message);
+    await page.waitForTimeout(1000);
+    await page.getByRole("button", { name: "Send" }).click();
+  }
+
+  /**
+   * Waits for a response matching the expected message(s)
+   */
+  private async waitForResponse(
+    page: Page,
+    expectedMessage?: string | string[],
+  ): Promise<boolean> {
+    // Wait for messages to appear in the virtuoso list
+    await page.waitForSelector('div[data-testid="virtuoso-item-list"] > div', {
+      timeout: defaultValues.streamTimeout,
+    });
+
+    // Get initial message count
+    const initialMessageCount = await page
+      .locator('div[data-testid="virtuoso-item-list"] > div')
+      .count();
+    console.log(`Initial message count: ${initialMessageCount}`);
+
+    // Convert expected message to array for consistent handling
+    const expectedPhrases = expectedMessage
+      ? Array.isArray(expectedMessage)
+        ? expectedMessage
+        : [expectedMessage]
+      : [];
+
+    // Poll for new messages
+    for (let i = 0; i < 30; i++) {
+      await page.waitForTimeout(1000);
+      const currentMessageCount = await page
+        .locator('div[data-testid="virtuoso-item-list"] > div')
+        .count();
+
+      if (currentMessageCount > initialMessageCount) {
+        const responseText = await this.getLatestMessageText(page);
+
+        // If no expected message, any response is valid
+        if (!expectedPhrases.length) {
+          console.log(`Received a response: "${responseText}"`);
+          return true;
+        }
+
+        // Check if any of the expected phrases are in the response
+        const messageFound = expectedPhrases.some((phrase) =>
+          responseText.toLowerCase().includes(phrase.toLowerCase()),
+        );
+
+        if (messageFound) {
+          console.log(
+            `Found expected response containing one of [${expectedPhrases.join(", ")}]: "${responseText}"`,
+          );
+          return true;
+        }
+      }
+    }
+
+    console.log(
+      expectedPhrases.length
+        ? `Failed to find response containing any of [${expectedPhrases.join(", ")}]`
+        : "Failed to receive any response",
+    );
+
+    return false;
+  }
+
+  /**
+   * Gets the text of the latest message in the conversation
+   */
+  private async getLatestMessageText(page: Page): Promise<string> {
+    const messageItems = await page
+      .locator('div[data-testid="virtuoso-item-list"] > div')
+      .all();
+
+    if (messageItems.length === 0) return "";
+
+    const latestMessageElement = messageItems[messageItems.length - 1];
+    const responseText = (await latestMessageElement.textContent()) || "";
+    console.log(`Latest message: "${responseText}"`);
+
+    return responseText;
+  }
+
+  /**
    * Starts a new page with the specified options
    */
-  private async startPage(
-    address?: string,
-  ): Promise<{ browser: Browser; page: Page }> {
-    this.browser = await chromium.launch({
+  private async startPage(address?: string): Promise<BrowserSession> {
+    const browser = await chromium.launch({
       headless: this.isHeadless,
       slowMo: this.isHeadless ? 0 : 100,
     });
 
-    const context: BrowserContext = await this.browser.newContext(
+    const context: BrowserContext = await browser.newContext(
       this.isHeadless ? {} : {},
     );
 
-    this.page = await context.newPage();
+    const page = await context.newPage();
 
     await this.setLocalStorage(
-      this.page,
+      page,
       this.defaultUser ? this.walletKey : "",
       this.defaultUser ? this.encryptionKey : "",
     );
 
-    let url = "https://xmtp.chat/";
-    if (address) {
-      url = `https://xmtp.chat/dm/${address}?env=${this.env}`;
-    }
+    const url = address
+      ? `https://xmtp.chat/dm/${address}?env=${this.env}`
+      : "https://xmtp.chat/";
+
     console.log("Navigating to:", url);
-    await this.page.goto(url);
-    await this.page.waitForTimeout(1000);
+    await page.goto(url);
+    await page.waitForTimeout(1000);
+
     if (!this.defaultUser) {
-      await this.page.getByText("Ephemeral", { exact: true }).click();
+      await page.getByText("Ephemeral", { exact: true }).click();
     }
 
-    return { browser: this.browser, page: this.page };
+    return { browser, page };
   }
 
   /**
@@ -256,11 +308,13 @@ export class XmtpPlaywright {
         walletEncryptionKey.slice(0, 4) + "...",
       );
     }
+
     await page.addInitScript(
       ({ envValue, walletKey, walletEncryptionKey }) => {
         if (walletKey !== "") console.log("Setting walletKey", walletKey);
         // @ts-expect-error Window localStorage access in browser context
         window.localStorage.setItem("XMTP_EPHEMERAL_ACCOUNT_KEY", walletKey);
+
         if (walletEncryptionKey !== "") {
           console.log("Setting walletEncryptionKey", walletEncryptionKey);
           // @ts-expect-error Window localStorage access in browser context
@@ -269,6 +323,7 @@ export class XmtpPlaywright {
             walletEncryptionKey,
           );
         }
+
         // @ts-expect-error Window localStorage access in browser context
         window.localStorage.setItem("XMTP_NETWORK", envValue);
         // @ts-expect-error Window localStorage access in browser context
@@ -276,33 +331,18 @@ export class XmtpPlaywright {
       },
       {
         envValue: this.env,
-        walletKey: walletKey,
-        walletEncryptionKey: walletEncryptionKey,
+        walletKey,
+        walletEncryptionKey,
       },
     );
   }
 
   /**
-   * Tests a DM with an agent using deeplink
+   * Safely closes the browser
    */
-  async newDmWithDeeplink(
-    address: string,
-    sendMessage: string,
-    expectedMessage?: string | string[],
-  ): Promise<boolean> {
-    const { page, browser } = await this.startPage(address);
-    try {
-      return await this.sendAndWaitForResponse(
-        page,
-        sendMessage,
-        expectedMessage,
-      );
-    } catch (error) {
-      console.error("Could not find expected message:", error);
-      await this.takeSnapshot(page, "before-finding-expected-message");
-      return false;
-    } finally {
-      if (browser) await browser.close();
+  private async closeBrowser(browser: Browser): Promise<void> {
+    if (browser) {
+      await browser.close();
     }
   }
 }

--- a/suites/TS_AgentHealth/TS_AgentHealth.test.ts
+++ b/suites/TS_AgentHealth/TS_AgentHealth.test.ts
@@ -18,7 +18,6 @@ interface Agent {
 
 // Type assertion for imported JSON
 const typedAgents = agentHealth as Agent[];
-const isGithubActions = process.env.GITHUB_ACTIONS === "true";
 const testName = "ts_agenthealth";
 loadEnv(testName);
 

--- a/suites/TS_AgentHealth/TS_AgentHealth.test.ts
+++ b/suites/TS_AgentHealth/TS_AgentHealth.test.ts
@@ -40,7 +40,10 @@ describe(testName, () => {
       it(`${agent.name} ${network}`, async () => {
         try {
           console.log(`Testing ${agent.name} on ${network}`);
-          const xmtpTester = new XmtpPlaywright(true, network as XmtpEnv);
+          const xmtpTester = new XmtpPlaywright({
+            headless: true,
+            env: network as XmtpEnv,
+          });
           const result = await xmtpTester.newDmWithDeeplink(
             agent.address,
             agent.sendMessage,

--- a/suites/TS_AgentHealth/agents.json
+++ b/suites/TS_AgentHealth/agents.json
@@ -4,7 +4,7 @@
     "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
     "networks": ["dev", "production"],
     "sendMessage": "hola",
-    "expectedMessage": "chat"
+    "expectedMessage": ["chat", "invalid"]
   },
   {
     "name": "stress",
@@ -25,6 +25,6 @@
     "address": "0x74563b2e03f8539ea0ee99a2d6c6b4791e652901",
     "networks": ["dev", "production"],
     "sendMessage": "hola",
-    "expectedMessage": "chat"
+    "expectedMessage": ["chat", "invalid"]
   }
 ]

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -17,7 +17,7 @@ describe(testName, () => {
   let convo: Conversation;
   let workers: WorkerManager;
   let hasFailures: boolean = false;
-  const xmtpTester = new XmtpPlaywright(false, "production");
+  const xmtpTester = new XmtpPlaywright({ headless: false, env: "production" });
 
   beforeAll(async () => {
     try {


### PR DESCRIPTION
### Refactor XmtpPlaywright constructor to use named object parameters and improve message handling in browser tests
* Refactors `XmtpPlaywright` class in [playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/220/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) to use named object parameters and adds new types `BrowserSession` and `XmtpPlaywrightOptions`
* Updates message handling in [agents.json](https://github.com/xmtp/xmtp-qa-testing/pull/220/files#diff-9fff9a9b7894e4b65b380f3a5c6c547454bf1d4cf0316909c56be329f8519261) to accept multiple valid response options ["chat", "invalid"]
* Removes deprecated `readGroupMessages` method and its documentation from [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/220/files#diff-dcc79850d85d413d98a1dcf06dab8d50f45c372b244edb818d3eaa8fcd33504b)
* Updates constructor calls across test files to use new object parameter style

#### 📍Where to Start
Start with the refactored `XmtpPlaywright` class in [playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/220/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) which contains the core changes to the constructor and message handling logic.

----

_[Macroscope](https://app.macroscope.com) summarized 130d061._