### PR TITLE
Refactor logAgentDetails to handle multiple clients

### DIFF
--- a/bots/helpers/xmtp-handler-workers.ts
+++ b/bots/helpers/xmtp-handler-workers.ts
@@ -1,11 +1,4 @@
 import {
-  createSigner,
-  generateEncryptionKeyHex,
-  getDbPath,
-  getEncryptionKeyFromHex,
-  logAgentDetails,
-} from "@helpers/client";
-import {
   Client,
   Dm,
   type Conversation,
@@ -13,6 +6,13 @@ import {
   type LogLevel,
   type XmtpEnv,
 } from "@xmtp/node-sdk";
+import {
+  createSigner,
+  generateEncryptionKeyHex,
+  getDbPath,
+  getEncryptionKeyFromHex,
+  logAgentDetails,
+} from "./client";
 import "dotenv/config";
 
 // Get environment variable

--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -1,11 +1,4 @@
 import {
-  createSigner,
-  generateEncryptionKeyHex,
-  getDbPath,
-  getEncryptionKeyFromHex,
-  logAgentDetails,
-} from "@helpers/client";
-import {
   Client,
   Dm,
   type Conversation,
@@ -13,6 +6,13 @@ import {
   type LogLevel,
   type XmtpEnv,
 } from "@xmtp/node-sdk";
+import {
+  createSigner,
+  generateEncryptionKeyHex,
+  getDbPath,
+  getEncryptionKeyFromHex,
+  logAgentDetails,
+} from "./client";
 import "dotenv/config";
 
 /**


### PR DESCRIPTION
### Modify `logAgentDetails` function in XMTP client helper to support single and multiple client logging with grouped address output
* Updates `logAgentDetails` function in [client.ts](https://github.com/xmtp/xmtp-qa-testing/pull/225/files#diff-b6775850c3855e0279365559a3f00e52492dcd0b6fb67dbc7ded48e780300dc6) to accept either single or multiple clients and group output by address
* Rewrites `validateEnvironment` function to automatically load environment variables from local .env file without requiring explicit path
* Updates import paths in [xmtp-handler-workers.ts](https://github.com/xmtp/xmtp-qa-testing/pull/225/files#diff-1f8010ff4b3e560f30324d62996d72f63ab7f25ce347aa3a9cb4e4db6358626f) and [xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-testing/pull/225/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) to use relative paths instead of aliases

#### 📍Where to Start
Start with the `logAgentDetails` function in [client.ts](https://github.com/xmtp/xmtp-qa-testing/pull/225/files#diff-b6775850c3855e0279365559a3f00e52492dcd0b6fb67dbc7ded48e780300dc6) which contains the main functional changes for handling client logging.

----

_[Macroscope](https://app.macroscope.com) summarized 206e9be._