### PR TITLE
Refactor performance timing for more accurate metrics

### DIFF
--- a/functional/dms.test.ts
+++ b/functional/dms.test.ts
@@ -15,9 +15,9 @@ import {
 } from "vitest";
 
 const testName = "dms";
+loadEnv(testName);
 
 describe(testName, () => {
-  loadEnv(testName);
   let convo: Conversation;
   let workers: WorkerManager;
   let hasFailures: boolean = false;

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -555,19 +555,6 @@ export async function sendPerformanceMetric(
 
     const isSuccess = metricValue <= threshold;
 
-    // Log additional information if provided
-    if (additionalInfo?.isDeliveryTime) {
-      console.log(
-        `✅ Message delivery time: ${metricValue.toFixed(2)}ms (actual message delivery only)`,
-      );
-
-      if (additionalInfo.totalTestTime) {
-        console.log(
-          `Total test time: ${additionalInfo.totalTestTime.toFixed(2)}ms (includes setup, etc.)`,
-        );
-      }
-    }
-
     console.log(
       JSON.stringify(
         {

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -73,20 +73,6 @@ yarn script generate
 
 **Expected result:** The script will generate test data according to its configuration.
 
-## 🌐 Hyperbrowser
-
-The `hyperbrowser.ts` script provides a headless browser automation tool for XMTP testing.
-
-```bash
-# Run the script with a specific URL
-yarn tsx scripts/hyperbrowser.ts --url="https://example.com"
-
-# Run with additional options
-yarn tsx scripts/hyperbrowser.ts --url="https://example.com" --headless=false --screenshot=true
-```
-
-**Expected result:** The script will launch a browser session to the specified URL, perform automated actions, and optionally take screenshots.
-
 **Options:**
 
 - `--url`: Target URL to navigate to


### PR DESCRIPTION
### Modify performance timing implementation to track both message delivery and total test time across XMTP test suites
Implements dual timing measurements across test suites by tracking both message delivery time and total test execution time. Key changes include:

* Adds `testStart` variable and modifies timing logic in [streams.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-742e52d366c3c595b9d4633e3824658f05027a69efbbb8dff923304f1f847953) and [TS_Performance.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-716e1ec0f3e907f24d321016214c7c7a880de303b1c5e07570a8de8866237720) to capture test start time
* Updates `sendPerformanceResult` and `sendPerformanceMetric` functions in [datadog.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to handle both timing metrics
* Modifies message sending callback timing in [streams.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to fire immediately after first message
* Relocates `loadEnv` function call in [dms.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-e73393b2a9052f11d2cd67bdd5fa2c49229d2c53325d268259b94c0485440ff2) to execute before test suite initialization

#### 📍Where to Start
Start with the `sendPerformanceResult` function in [datadog.ts](https://github.com/xmtp/xmtp-qa-testing/pull/228/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) which handles the core timing metric collection and reporting logic.

----

_[Macroscope](https://app.macroscope.com) summarized 72bc510._