### PR TITLE
Refactor stream types for improved clarity and consistency

### DIFF
--- a/.cursor/rules/test-practices.mdc
+++ b/.cursor/rules/test-practices.mdc
@@ -3,160 +3,68 @@ description:
 globs: 
 alwaysApply: true
 ---
-import { closeEnv, loadEnv } from "@helpers/client";
-import { sendPerformanceResult, sendTestResults } from "@helpers/datadog";
-import generatedInboxes from "@helpers/generated-inboxes.json";
+import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { verifyStream, verifyStreamAll } from "@helpers/streams";
-import { getWorkers, type WorkerManager } from "@workers/manager";
-import {
-  Client,
-  IdentifierKind,
-  type Conversation,
-  type Group,
-} from "@xmtp/node-sdk";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "vitest";
+import { verifyStream } from "@helpers/streams";
+import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
+import { getWorkers } from "@workers/manager";
+import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
+import { describe, expect, it } from "vitest";
 
-const testName = "ts_performance";
+const testName = "dms";
 loadEnv(testName);
 
-const batchSize = parseInt(
-  process.env.CLI_BATCH_SIZE ?? process.env.BATCH_SIZE ?? "5",
-);
-const total = parseInt(
-  process.env.CLI_GROUP_SIZE ?? process.env.MAX_GROUP_SIZE ?? "10",
-);
-console.log(`[${testName}] Batch size: ${batchSize}, Total: ${total}`);
-
-describe(testName, () => {
-  let dm: Conversation;
-  let workers: WorkerManager;
-  let start: number;
+describe(testName, async () => {
+  const workers = await getWorkers(
+    [
+      "henry",
+      "ivy",
+      "jack",
+      "karen",
+      "randomguy",
+      "randomguy2",
+      "larry",
+      "mary",
+      "nancy",
+      "oscar",
+    ],
+    testName,
+  );
+  let convo: Conversation;
   let hasFailures: boolean = false;
+  let start: number;
+  let testStart: number;
 
-  beforeAll(async () => {
-    try {
-      workers = await getWorkers(
-        [
-          "henry-a-203",
-          "ivy-a-100",
-          "jack-a-202",
-          "karen-a-100",
-          "randomguy-a-100",
-          "randomguy2-a-203",
-          "larry-a-100",
-          "mary-a-105",
-          "nancy-a-100",
-          "oscar-a-105",
-        ],
-        testName,
-      );
-      expect(workers).toBeDefined();
-      expect(workers.getWorkers().length).toBe(10);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  beforeEach(() => {
-    const testName = expect.getState().currentTestName;
-    start = performance.now();
-    console.time(testName);
+  setupTestLifecycle({
+    expect,
+    workers,
+    testName,
+    hasFailuresRef: hasFailures,
+    getStart: () => start,
+    setStart: (v) => {
+      start = v;
+    },
+    getTestStart: () => testStart,
+    setTestStart: (v) => {
+      testStart = v;
+    },
   });
 
-  afterEach(function () {
-    try {
-      sendPerformanceResult(expect, workers, start);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-
-  afterAll(async () => {
-    try {
-      sendTestResults(hasFailures, testName);
-      await closeEnv(testName, workers);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-
-  it("clientCreate: should measure creating a client", async () => {
-    try {
-      const client = await getWorkers(["randomclient"], testName, "message");
-      expect(client).toBeDefined();
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it("canMessage: should measure canMessage", async () => {
-    try {
-      const client = await getWorkers(["randomclient"], testName, "none");
-      if (!client) {
-        throw new Error("Client not found");
-      }
-
-      const randomAddress = client.get("randomclient")!.address;
-      if (!randomAddress) {
-        throw new Error("Random client not found");
-      }
-      const canMessage = await Client.canMessage(
-        [
-          {
-            identifier: randomAddress,
-            identifierKind: IdentifierKind.Ethereum,
-          },
-        ],
-        client.get("randomclient")!.env,
-      );
-      expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it("inboxState: should measure inboxState of henry", async () => {
-    try {
-      const inboxState = await workers
-        .get("henry")!
-        .client.preferences.inboxState(true);
-      expect(inboxState.installations.length).toBeGreaterThan(0);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
   it("newDm: should measure creating a DM", async () => {
     try {
-      dm = await workers
+      convo = await workers
         .get("henry")!
         .client.conversations.newDm(workers.get("randomguy")!.client.inboxId);
 
-      expect(dm).toBeDefined();
-      expect(dm.id).toBeDefined();
+      expect(convo).toBeDefined();
+      expect(convo.id).toBeDefined();
     } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
+      hasFailures = logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
+
   it("newDmWithIdentifiers: should measure creating a DM", async () => {
     try {
       const dm2 = await workers
@@ -169,249 +77,47 @@ describe(testName, () => {
       expect(dm2).toBeDefined();
       expect(dm2.id).toBeDefined();
     } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
+      hasFailures = logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
-
   it("sendGM: should measure sending a gm", async () => {
     try {
-      // We'll expect this random message to appear in Joe's stream
       const message = "gm-" + Math.random().toString(36).substring(2, 15);
 
       console.log(
-        `[${workers.get("henry")!.name}] Creating DM with ${workers.get("randomguy")!.name} at ${workers.get("randomguy")!.client.inboxId}`,
+        `[${workers.get("henry")?.name}] Creating DM with ${workers.get("randomguy")?.name} at ${workers.get("randomguy")?.client.inboxId}`,
       );
 
-      const dmId = await dm.send(message);
+      const dmId = await convo.send(message);
 
       expect(dmId).toBeDefined();
     } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
+      hasFailures = logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
 
   it("receiveGM: should measure receiving a gm", async () => {
     try {
-      const verifyResult = await verifyStream(dm, [workers.get("randomguy")!]);
+      const verifyResult = await verifyStream(
+        convo,
+        [workers.get("randomguy")!],
+        typeofStream.Message,
+        1,
+        undefined,
+        undefined,
+        () => {
+          console.log("Message sent, starting timer now");
+          start = performance.now();
+        },
+      );
 
       expect(verifyResult.messages.length).toEqual(1);
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
+      hasFailures = logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
-  let i = 4;
-  let newGroup: Conversation;
-  it(`createGroup: should create a large group of ${i} participants ${i}`, async () => {
-    try {
-      const sliced = generatedInboxes.slice(0, i);
-      newGroup = await workers
-        .get("henry")!
-        .client.conversations.newGroup(sliced.map((inbox) => inbox.inboxId));
-      console.log("New group created", newGroup.id);
-      expect(newGroup.id).toBeDefined();
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`createGroupByIdentifiers: should create a large group of ${i} participants ${i}`, async () => {
-    try {
-      const sliced = generatedInboxes.slice(0, i);
-      const newGroupByIdentifier = await workers
-        .get("henry")!
-        .client.conversations.newGroupWithIdentifiers(
-          sliced.map((inbox) => ({
-            identifier: inbox.accountAddress,
-            identifierKind: IdentifierKind.Ethereum,
-          })),
-        );
-      expect(newGroupByIdentifier.id).toBeDefined();
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`syncGroup: should sync a large group of ${i} participants ${i}`, async () => {
-    try {
-      await newGroup.sync();
-      const members = await newGroup.members();
-      expect(members.length).toBe(i + 1);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`updateGroupName: should update the group name`, async () => {
-    try {
-      const newName = "Large Group";
-      await (newGroup as Group).updateName(newName);
-      await newGroup.sync();
-      const name = (newGroup as Group).name;
-      expect(name).toBe(newName);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-
-  it(`addMembers: should add members to a group`, async () => {
-    try {
-      await (newGroup as Group).addMembers([workers.get("randomguy")!.inboxId]);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`removeMembers: should remove a participant from a group`, async () => {
-    try {
-      const previousMembers = await newGroup.members();
-      await (newGroup as Group).removeMembers([
-        previousMembers.filter(
-          (member) => member.inboxId !== (newGroup as Group).addedByInboxId,
-        )[0].inboxId,
-      ]);
-
-      const members = await newGroup.members();
-      expect(members.length).toBe(previousMembers.length - 1);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`sendGroupMessage: should measure sending a gm in a group of ${i} participants`, async () => {
-    try {
-      const groupMessage = "gm-" + Math.random().toString(36).substring(2, 15);
-
-      await newGroup.send(groupMessage);
-      console.log("GM Message sent in group", groupMessage);
-      expect(groupMessage).toBeDefined();
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-  it(`receiveGroupMessage: should create a group and measure all streams`, async () => {
-    try {
-      const verifyResult = await verifyStreamAll(newGroup, workers);
-      expect(verifyResult.allReceived).toBe(true);
-    } catch (e) {
-      hasFailures = 
-      logError(e, expect.getState().currentTestName);
-      throw e;
-    }
-  });
-
-  for (let i = batchSize; i <= total; i += batchSize) {
-    let newGroup: Conversation;
-    it(`createGroup-${i}: should create a large group of ${i} participants ${i}`, async () => {
-      try {
-        const sliced = generatedInboxes.slice(0, i);
-        newGroup = await workers
-          .get("henry")!
-          .client.conversations.newGroup(sliced.map((inbox) => inbox.inboxId));
-        expect(newGroup.id).toBeDefined();
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`createGroupByIdentifiers-${i}: should create a large group of ${i} participants ${i}`, async () => {
-      try {
-        const sliced = generatedInboxes.slice(0, i);
-        const newGroupByIdentifier = await workers
-          .get("henry")!
-          .client.conversations.newGroupWithIdentifiers(
-            sliced.map((inbox) => ({
-              identifier: inbox.accountAddress,
-              identifierKind: IdentifierKind.Ethereum,
-            })),
-          );
-        expect(newGroupByIdentifier.id).toBeDefined();
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`syncGroup-${i}: should sync a large group of ${i} participants ${i}`, async () => {
-      try {
-        await newGroup.sync();
-        const members = await newGroup.members();
-        expect(members.length).toBe(i + 1);
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`updateGroupName-${i}: should update the group name`, async () => {
-      try {
-        const newName = "Large Group";
-        await (newGroup as Group).updateName(newName);
-        await newGroup.sync();
-        const name = (newGroup as Group).name;
-        expect(name).toBe(newName);
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`removeMembers-${i}: should remove a participant from a group`, async () => {
-      try {
-        const previousMembers = await newGroup.members();
-        await (newGroup as Group).removeMembers([
-          previousMembers.filter(
-            (member) => member.inboxId !== (newGroup as Group).addedByInboxId,
-          )[0].inboxId,
-        ]);
-
-        const members = await newGroup.members();
-        expect(members.length).toBe(previousMembers.length - 1);
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`sendGroupMessage-${i}: should measure sending a gm in a group of ${i} participants`, async () => {
-      try {
-        const groupMessage =
-          "gm-" + Math.random().toString(36).substring(2, 15);
-
-        await newGroup.send(groupMessage);
-        console.log("GM Message sent in group", groupMessage);
-        expect(groupMessage).toBeDefined();
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-    it(`receiveGroupMessage-${i}: should create a group and measure all streams`, async () => {
-      try {
-        const verifyResult = await verifyStreamAll(newGroup, workers);
-        expect(verifyResult.allReceived).toBe(true);
-      } catch (e) {
-        hasFailures = 
-      logError(e, expect.getState().currentTestName);
-        throw e;
-      }
-    });
-  }
 });

--- a/bots/README.md
+++ b/bots/README.md
@@ -42,8 +42,8 @@ The `agents` bot provides AI-powered chat personalities using GPT integration.
 const workersGpt = await getWorkers(
   ["sam", "tina", "walt"],
   testName,
-  "message",
-  "gpt",
+  typeofStream.Message,
+  typeOfResponse.Gpt,
 );
 ```
 

--- a/bots/personas/index.ts
+++ b/bots/personas/index.ts
@@ -1,3 +1,4 @@
+import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 
 async function main() {
@@ -6,8 +7,8 @@ async function main() {
     const workersGpt = await getWorkers(
       ["sam", "tina", "walt"],
       "test-bot",
-      "message",
-      "gpt",
+      typeofStream.Message,
+      typeOfResponse.Gpt,
     );
     for (const worker of workersGpt.getWorkers()) {
       // Add sync log to track if sync causes issues

--- a/bots/simple/index.ts
+++ b/bots/simple/index.ts
@@ -1,9 +1,15 @@
+import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { type Client, type XmtpEnv } from "@xmtp/node-sdk";
 
 async function main() {
   // Get 20 dynamic workers
-  const workers = await getWorkers(["bot"], "test-bot", "message", "gpt");
+  const workers = await getWorkers(
+    ["bot"],
+    "test-bot",
+    typeofStream.Message,
+    typeOfResponse.Gpt,
+  );
   const bot = workers.get("bot");
   const client = bot?.client as Client;
   console.log(`Agent initialized on address ${bot?.address}`);
@@ -39,7 +45,7 @@ async function main() {
           continue;
         }
         console.log("conversation", conversation.id);
-        console.log("message", message.senderInboxId);
+        console.log("senderInboxId", message.senderInboxId);
 
         const inboxState = await client.preferences.inboxStateFromInboxIds([
           message.senderInboxId,

--- a/bots/test/index.ts
+++ b/bots/test/index.ts
@@ -1,3 +1,4 @@
+import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type {
   Client,
@@ -14,8 +15,18 @@ async function main() {
 
     // Then create the dynamic workers
     console.log("Initializing worker workers...");
-    const workers = await getWorkers(20, "test-bot", "message", "gpt");
-    const botWorker = await getWorkers(["bot"], "test-bot", "message", "gpt");
+    const workers = await getWorkers(
+      20,
+      "test-bot",
+      typeofStream.Message,
+      typeOfResponse.Gpt,
+    );
+    const botWorker = await getWorkers(
+      ["bot"],
+      "test-bot",
+      typeofStream.Message,
+      typeOfResponse.Gpt,
+    );
     const bot = botWorker.get("bot");
     const client = bot?.client as Client;
 

--- a/bugs/bug_stitch/README.md
+++ b/bugs/bug_stitch/README.md
@@ -17,7 +17,7 @@ yarn test bug_stitch
 const workers = await getWorkers(
   ["ivy-a-202"],
   testName,
-  "message",
+  typeofStream.Message,
   false,
   undefined,
   env,
@@ -36,7 +36,7 @@ await ivy100?.worker.initialize();
 const workers = await getWorkers(
   ["ivy-b-105"],
   testName,
-  "message",
+  typeofStream.Message,
   false,
   undefined,
   env,

--- a/bugs/bug_stitch/stitch.test.ts
+++ b/bugs/bug_stitch/stitch.test.ts
@@ -35,7 +35,7 @@ describe(testName, () => {
       it("should initialize clients and sync conversations", async () => {
         try {
           console.log(`Setting up test for ${user}`);
-          const workers = await getWorkers(["ivy-a-202"], testName, "message");
+          const workers = await getWorkers(["ivy-a-202"], testName);
           ivy100 = workers.get("ivy", "a") as Worker;
           console.log("syncing all");
           await ivy100?.client.conversations.sync();
@@ -81,7 +81,7 @@ describe(testName, () => {
       it("should initialize clients and sync conversations", async () => {
         try {
           console.log(`Setting up test for ${user}]`);
-          const workers = await getWorkers(["ivy-b-105"], testName, "message");
+          const workers = await getWorkers(["ivy-b-105"], testName);
           ivy105 = workers.get("ivy", "b") as Worker;
           console.log("syncing all");
           await ivy105?.client.conversations.sync();
@@ -108,7 +108,7 @@ describe(testName, () => {
       it("should initialize clients and sync conversations", async () => {
         try {
           console.log(`Setting up test for ${user}]`);
-          const workers = await getWorkers(["ivy-c-202"], testName, "message");
+          const workers = await getWorkers(["ivy-c-202"], testName);
           ivy200 = workers.get("ivy", "c") as Worker;
           console.log("syncing all");
           await ivy200?.client.conversations.sync();

--- a/functional/clients.test.ts
+++ b/functional/clients.test.ts
@@ -1,6 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { Client, IdentifierKind, type Identifier } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -46,7 +47,7 @@ describe(testName, async () => {
 
   it("clientCreate: should measure creating a client", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName, "message");
+      const client = await getWorkers(["randomclient"], testName);
       expect(client).toBeDefined();
     } catch (e) {
       logError(e, expect.getState().currentTestName);

--- a/functional/consent.test.ts
+++ b/functional/consent.test.ts
@@ -1,5 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { ConsentEntityType, ConsentState } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -26,7 +27,7 @@ describe(testName, async () => {
       "oscar",
     ],
     testName,
-    "consent",
+    typeofStream.Consent,
   );
 
   setupTestLifecycle({

--- a/functional/conversations.test.ts
+++ b/functional/conversations.test.ts
@@ -1,6 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { verifyConversationStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
@@ -25,7 +26,7 @@ describe(testName, async () => {
       "oscar",
     ],
     testName,
-    "conversation",
+    typeofStream.Conversation,
   );
 
   setupTestLifecycle({

--- a/functional/dms.test.ts
+++ b/functional/dms.test.ts
@@ -2,6 +2,7 @@ import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -97,7 +98,7 @@ describe(testName, async () => {
       const verifyResult = await verifyStream(
         convo,
         [workers.get("randomguy")!],
-        "text",
+        typeofStream.Message,
         1,
         undefined,
         undefined,

--- a/functional/metadata.test.ts
+++ b/functional/metadata.test.ts
@@ -1,6 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { verifyStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -62,7 +63,7 @@ describe(testName, async () => {
     const verifyResult = await verifyStream(
       group,
       [workers.get("oscar")!],
-      "group_updated",
+      typeofStream.GroupUpdated,
     );
     expect(verifyResult.allReceived).toBe(true);
     console.timeEnd("update group name");

--- a/functional/order.test.ts
+++ b/functional/order.test.ts
@@ -3,6 +3,7 @@ import { getWorkersFromGroup } from "@helpers/groups";
 import { verifyStream, type VerifyStreamResult } from "@helpers/streams";
 import { calculateMessageStats } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -53,7 +54,7 @@ describe(testName, async () => {
     collectedMessages = await verifyStream(
       group,
       workers.getWorkers(),
-      "text",
+      typeofStream.Message,
       amount,
       (index) => `gm-${index + 1}-${randomSuffix}`,
     );

--- a/functional/streams.test.ts
+++ b/functional/streams.test.ts
@@ -2,6 +2,7 @@ import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyStream, verifyStreamAll } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
@@ -41,7 +42,7 @@ describe(testName, async () => {
       const verifyResult = await verifyStream(
         convo,
         [workers.get("randomguy")!],
-        "text",
+        typeofStream.Message,
         1,
         undefined,
         undefined,

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -1,4 +1,5 @@
 import { getWorkersFromGroup } from "@helpers/groups";
+import { typeofStream } from "@workers/main";
 import type { Worker, WorkerManager } from "@workers/manager";
 import { type Conversation, type Group } from "@xmtp/node-sdk";
 import { defaultValues } from "./tests";
@@ -51,7 +52,7 @@ export async function verifyStreamAll(
   return verifyStream(
     group,
     allWorkers,
-    "text",
+    typeofStream.Message,
     count,
     undefined,
     undefined,
@@ -65,7 +66,7 @@ export async function verifyStreamAll(
 export async function verifyStream<T extends string = string>(
   group: Conversation,
   participants: Worker[],
-  collectorType = "text",
+  collectorType = typeofStream.Message,
   count = 1,
   generator: (i: number, suffix: string) => T = (i, suffix): T =>
     `gm-${i + 1}-${suffix}` as T,
@@ -76,7 +77,7 @@ export async function verifyStream<T extends string = string>(
   onMessageSent?: () => void,
 ): Promise<VerifyStreamResult> {
   // Use name updater for group_updated collector type
-  if (collectorType === "group_updated") {
+  if (collectorType === typeofStream.GroupUpdated) {
     generator = ((i: number, suffix: string) =>
       `New name-${i + 1}-${suffix}`) as unknown as typeof generator;
     sender = (async (g: Group, payload: string) => {
@@ -107,7 +108,7 @@ export async function verifyStream<T extends string = string>(
 
   // Start collectors
   let collectPromises: Promise<T[]>[] = [];
-  if (collectorType === "text") {
+  if (collectorType === typeofStream.Message) {
     collectPromises = receivers.map((r) => {
       if (!r.worker) {
         return Promise.resolve([]);
@@ -118,7 +119,7 @@ export async function verifyStream<T extends string = string>(
           return msgs.map((m) => m.message.content as T);
         });
     });
-  } else if (collectorType === "group_updated") {
+  } else if (collectorType === typeofStream.GroupUpdated) {
     collectPromises = receivers.map((r) => {
       if (!r.worker) {
         return Promise.resolve([]);

--- a/suites/TS_Delivery/TS_Delivery.test.ts
+++ b/suites/TS_Delivery/TS_Delivery.test.ts
@@ -5,6 +5,7 @@ import { logError } from "@helpers/logger";
 import { verifyStream, type VerifyStreamResult } from "@helpers/streams";
 import { calculateMessageStats } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -69,7 +70,7 @@ describe(testName, async () => {
       collectedMessages = await verifyStream(
         group,
         workers.getWorkers(),
-        "text",
+        typeofStream.Message,
         amountofMessages,
         (index) => `gm-${index + 1}-${randomSuffix}`,
       );

--- a/suites/TS_Fork/TS_Fork.test.ts
+++ b/suites/TS_Fork/TS_Fork.test.ts
@@ -51,7 +51,7 @@ describe(TEST_NAME, () => {
     console.time("initialize workers and create group");
 
     // Initialize workers
-    workers = await getWorkers(testConfig.workers, TEST_NAME, "message", "gm");
+    workers = await getWorkers(testConfig.workers, TEST_NAME);
     creator = workers.get("fabri") as Worker;
     const allWorkers = workers.getWorkers();
     const allClientIds = [

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -4,6 +4,7 @@ import { logError } from "@helpers/logger";
 import { XmtpPlaywright } from "@helpers/playwright";
 import { defaultValues } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -20,7 +21,13 @@ describe(testName, async () => {
   let start: number;
   let testStart: number;
   const xmtpTester = new XmtpPlaywright({ headless: false, env: "production" });
-  workers = await getWorkers(["bob"], testName, "message", "gm", "production");
+  workers = await getWorkers(
+    ["bob"],
+    testName,
+    typeofStream.Message,
+    typeOfResponse.Gm,
+    "production",
+  );
 
   setupTestLifecycle({
     expect,

--- a/suites/TS_Performance/TS_Performance.test.ts
+++ b/suites/TS_Performance/TS_Performance.test.ts
@@ -3,6 +3,7 @@ import generatedInboxes from "@helpers/generated-inboxes.json";
 import { logError } from "@helpers/logger";
 import { verifyStream, verifyStreamAll } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import {
   Client,
@@ -33,8 +34,8 @@ describe(testName, async () => {
   workers = await getWorkers(
     10,
     testName,
-    "message",
-    "none",
+    typeofStream.Message,
+    typeOfResponse.None,
     process.env.XMTP_ENV as XmtpEnv,
     true,
   );
@@ -56,7 +57,7 @@ describe(testName, async () => {
 
   it("clientCreate: should measure creating a client", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName, "message");
+      const client = await getWorkers(["randomclient"], testName);
       expect(client).toBeDefined();
     } catch (e) {
       hasFailures = logError(e, expect.getState().currentTestName);
@@ -65,7 +66,11 @@ describe(testName, async () => {
   });
   it("canMessage: should measure canMessage", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName, "none");
+      const client = await getWorkers(
+        ["randomclient"],
+        testName,
+        typeofStream.None,
+      );
       if (!client) {
         throw new Error("Client not found");
       }
@@ -149,7 +154,7 @@ describe(testName, async () => {
       const verifyResult = await verifyStream(
         dm,
         [workers.getWorkers()[1]],
-        "text",
+        typeofStream.Message,
         1,
         undefined,
         undefined,

--- a/suites/TS_Stress/TS_Stress.test.ts
+++ b/suites/TS_Stress/TS_Stress.test.ts
@@ -27,7 +27,7 @@ console.log(
 
 describe(testName, async () => {
   let workers: WorkerManager;
-  workers = await getWorkers(["bot"], testName, "message", "none");
+  workers = await getWorkers(["bot"], testName);
   let bot: Worker;
   let client: Client;
   let conversation: Conversation;

--- a/workers/README.md
+++ b/workers/README.md
@@ -79,7 +79,7 @@ const alicePhoneConversations = await alicePhone.client.conversations.list();
 
 ```typescript
 // Set up worker with message streaming
-const workers = await getWorkers(["alice", "bob"], testName, "message");
+const workers = await getWorkers(["alice", "bob"], testName);
 const alice = workers.get("alice");
 const bob = workers.get("bob");
 
@@ -103,7 +103,12 @@ console.log(`Received message: ${incomingMessages[0].message.content}`);
 
 ```typescript
 // Create workers with GPT-powered responses
-const workers = await getWorkers(["alice", "bob"], testName, "message", true);
+const workers = await getWorkers(
+  ["alice", "bob"],
+  testName,
+  typeofStream.Message,
+  typeOfResponse.Gpt,
+);
 const alice = workers.get("alice");
 const bob = workers.get("bob");
 

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -462,7 +462,18 @@ export class WorkerClient extends Worker {
     return new Promise((resolve) => {
       const events: T[] = [];
       const onMessage = (msg: StreamMessage) => {
-        const isRightType = msg.type === `stream_${type}`;
+        // Map from typeofStream to StreamCollectorType
+        const streamTypeMap: Record<typeofStream, StreamCollectorType | null> =
+          {
+            [typeofStream.Message]: StreamCollectorType.Message,
+            [typeofStream.GroupUpdated]: StreamCollectorType.GroupUpdated,
+            [typeofStream.Conversation]: StreamCollectorType.Conversation,
+            [typeofStream.Consent]: StreamCollectorType.Consent,
+            [typeofStream.None]: null,
+          };
+
+        const expectedType = streamTypeMap[type];
+        const isRightType = expectedType !== null && msg.type === expectedType;
         const passesFilter = !filterFn || filterFn(msg);
 
         if (isRightType && passesFilter) {

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -5,15 +5,7 @@ import { generateEncryptionKeyHex } from "@helpers/client";
 import { defaultValues, sdkVersionOptions, sdkVersions } from "@helpers/tests";
 import { type Client, type XmtpEnv } from "@xmtp/node-sdk";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-import { WorkerClient } from "./main";
-
-export type typeofStream =
-  | "message"
-  | "conversation"
-  | "consent"
-  | "group_updated"
-  | "none";
-export type typeOfResponse = "gm" | "gpt" | "none";
+import { typeOfResponse, typeofStream, WorkerClient } from "./main";
 
 export interface WorkerBase {
   name: string;
@@ -46,8 +38,8 @@ export class WorkerManager {
   private workers: Record<string, Record<string, Worker>>;
   private testName: string;
   private activeWorkers: WorkerClient[] = [];
-  private typeofStream: typeofStream = "message";
-  private typeOfResponse: typeOfResponse = "gm";
+  private typeofStream: typeofStream = typeofStream.Message;
+  private typeOfResponse: typeOfResponse = typeOfResponse.Gm;
   private env: XmtpEnv;
   private keysCache: Record<
     string,
@@ -59,13 +51,13 @@ export class WorkerManager {
    */
   constructor(
     testName: string,
-    typeofStream: typeofStream = "message",
-    typeOfResponse: typeOfResponse = "gm",
+    typeofStreamType: typeofStream = typeofStream.Message,
+    typeOfResponseType: typeOfResponse = typeOfResponse.Gm,
     env: XmtpEnv,
   ) {
     this.testName = testName;
-    this.typeofStream = typeofStream;
-    this.typeOfResponse = typeOfResponse;
+    this.typeofStream = typeofStreamType;
+    this.typeOfResponse = typeOfResponseType;
     this.env = env;
     this.workers = {};
   }
@@ -371,15 +363,15 @@ export class WorkerManager {
 export async function getWorkers(
   descriptorsOrAmount: string[] | number,
   testName: string,
-  typeofStream: typeofStream = "message",
-  typeOfResponse: typeOfResponse = "gm",
+  typeofStreamType: typeofStream = typeofStream.Message,
+  typeOfResponseType: typeOfResponse = typeOfResponse.Gm,
   env: XmtpEnv = process.env.XMTP_ENV as XmtpEnv,
   randomVersions: boolean = false,
 ): Promise<WorkerManager> {
   const manager = new WorkerManager(
     testName,
-    typeofStream,
-    typeOfResponse,
+    typeofStreamType,
+    typeOfResponseType,
     env,
   );
   await manager.createWorkers(descriptorsOrAmount, randomVersions);


### PR DESCRIPTION
### Replace string literals with type-safe enums for stream and response types across worker initialization and stream verification functions
* Introduces new type-safe enums `typeOfResponse`, `typeofStream`, and `StreamCollectorType` in [main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/234/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) to replace string literals for stream and response type specifications
* Renames worker event from "message" to "worker_message" to avoid confusion with standard Worker events
* Updates stream message interfaces, initialization methods, and collection logic to use the new enum system in [main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/234/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1)
* Refactors test lifecycle management in [test-practices.mdc](https://github.com/xmtp/xmtp-qa-testing/pull/234/files#diff-315ea846277b58a2e7d8ab84ec3d39a1c3d1fc37c95251b1b11d027daa9a3196) to use `setupTestLifecycle` helper
* Updates worker initialization and stream verification calls across 20+ test and bot files to use the new enum-based approach

#### 📍Where to Start
Start with the enum definitions and updated stream handling logic in [main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/234/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1), which contains the core changes that propagate throughout the codebase.

----

_[Macroscope](https://app.macroscope.com) summarized 012bc41._