### PR TITLE
Rename test jobs for clarity and consistency

### DIFF
--- a/.github/workflows/TS_AgentHealth.yml
+++ b/.github/workflows/TS_AgentHealth.yml
@@ -10,7 +10,7 @@ on:
   #     - main
 
 jobs:
-  test:
+  TS_AgentHealth:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/TS_Delivery.yml
+++ b/.github/workflows/TS_Delivery.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  TS_Delivery:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/TS_Geolocation.yml
+++ b/.github/workflows/TS_Geolocation.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  TS_Geolocation:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/TS_Gm.yml
+++ b/.github/workflows/TS_Gm.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  TS_Gm:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/TS_Performance.yml
+++ b/.github/workflows/TS_Performance.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  TS_Performance:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
### Rename GitHub workflow test jobs to match their workflow file names for clarity and consistency
Updates job names in GitHub workflow files to match their respective workflow file names:
* [TS_AgentHealth.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-fa5226b9e45154a8355cbaf85933a4bed1969c8c8918d27c7a0b2351a2621aae): Renamed job from `test` to `TS_AgentHealth`
* [TS_Delivery.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-3034651e94fbc806fe1b40a9268b5a33e85e285011ef31873e9a5c36345a2620): Renamed job from `test` to `TS_Delivery`
* [TS_Geolocation.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-e513068c1f136d0b1cfac3f8ed53e516651033036abeaba3cde7d4babe1bbd6b): Renamed job from `test` to `TS_Geolocation`
* [TS_Gm.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-4245381c88c6b56b1279b32efe92391d812f1b5261c4d41edfbba998f72148d0): Renamed job from `test` to `TS_Gm`
* [TS_Performance.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-9400d484963f10f3b13b82476765a9352d928964c4e788df8f272ce591a7eb2d): Renamed job from `test` to `TS_Performance`

#### 📍Where to Start
Start with [TS_AgentHealth.yml](https://github.com/xmtp/xmtp-qa-testing/pull/238/files#diff-fa5226b9e45154a8355cbaf85933a4bed1969c8c8918d27c7a0b2351a2621aae) as it's the first workflow file being modified. The changes follow the same pattern across all files.

----

_[Macroscope](https://app.macroscope.com) summarized d80f93a._