### PR TITLE
Refactor tests to remove hasFailures tracking logic

### DIFF
--- a/.cursor/rules/test-practices.mdc
+++ b/.cursor/rules/test-practices.mdc
@@ -7,7 +7,6 @@ import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
@@ -32,7 +31,7 @@ describe(testName, async () => {
     testName,
   );
   let convo: Conversation;
-  
+
   let start: number;
   let testStart: number;
 
@@ -102,17 +101,8 @@ describe(testName, async () => {
       const verifyResult = await verifyMessageStream(
         convo,
         [workers.get("randomguy")!],
-        typeofStream.Message,
         1,
-        undefined,
-        undefined,
-        () => {
-          console.log("Message sent, starting timer now");
-          start = performance.now();
-        },
       );
-
-      expect(verifyResult.messages.length).toEqual(1);
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
       logError(e, expect.getState().currentTestName);

--- a/.cursor/rules/test-practices.mdc
+++ b/.cursor/rules/test-practices.mdc
@@ -32,7 +32,7 @@ describe(testName, async () => {
     testName,
   );
   let convo: Conversation;
-  let hasFailures: boolean = false;
+  
   let start: number;
   let testStart: number;
 
@@ -40,7 +40,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -60,7 +59,7 @@ describe(testName, async () => {
       expect(convo).toBeDefined();
       expect(convo.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -77,7 +76,7 @@ describe(testName, async () => {
       expect(dm2).toBeDefined();
       expect(dm2.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -93,7 +92,7 @@ describe(testName, async () => {
 
       expect(dmId).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -116,7 +115,7 @@ describe(testName, async () => {
       expect(verifyResult.messages.length).toEqual(1);
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -27,9 +27,7 @@ jobs:
           GM_BOT_ADDRESS: ${{ vars.GM_BOT_ADDRESS }}
           GITHUB_ACTIONS: true
           LOGGING_LEVEL: "off"
-        run: |
-          yarn script versions
-          ./scripts/run-test.sh functional 1
+        run: ./scripts/run-test.sh functional 1
 
       - name: Upload reports artifacts
         if: always()

--- a/.github/workflows/TS_Large.yml
+++ b/.github/workflows/TS_Large.yml
@@ -2,8 +2,6 @@ name: TS_Large
 description: "should verify performance of the group streams"
 
 on:
-  pull_request:
-    branches: [main]
   schedule:
     - cron: "0 */2 * * *" # Runs every 2 hours
   workflow_dispatch:

--- a/.github/workflows/check-agent-examples.yml
+++ b/.github/workflows/check-agent-examples.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Create .env file
         run: echo "XMTP_ENV=local" > .env
 
-      - name: Print versions
-        run: yarn script versions
-
       - name: Run agent
         run: |
           cd xmtp-agent-examples

--- a/functional/browser.test.ts
+++ b/functional/browser.test.ts
@@ -16,7 +16,6 @@ describe(testName, () => {
   const gmBotAddress = process.env.GM_BOT_ADDRESS;
 
   it("should respond to a message", async () => {
-    console.log("sending gm to bot", gmBotAddress);
     try {
       if (!gmBotAddress) {
         throw new Error("GM_BOT_ADDRESS environment variable is not set");

--- a/functional/clients.test.ts
+++ b/functional/clients.test.ts
@@ -10,7 +10,7 @@ loadEnv(testName);
 
 describe(testName, async () => {
   let workers: WorkerManager;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
   workers = await getWorkers(
@@ -33,7 +33,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;

--- a/functional/codec-error.test.ts
+++ b/functional/codec-error.test.ts
@@ -14,7 +14,6 @@ describe(testName, async () => {
   let workers: WorkerManager;
   workers = await getWorkers(["henry", "ivy"], testName);
 
-  let hasFailures: boolean = false;
   let start: number;
   let testStart: number;
 
@@ -22,7 +21,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;

--- a/functional/dms.test.ts
+++ b/functional/dms.test.ts
@@ -26,7 +26,7 @@ describe(testName, async () => {
     testName,
   );
   let convo: Conversation;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
 
@@ -34,7 +34,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -54,7 +53,7 @@ describe(testName, async () => {
       expect(convo).toBeDefined();
       expect(convo.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -71,7 +70,7 @@ describe(testName, async () => {
       expect(dm2).toBeDefined();
       expect(dm2.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -87,7 +86,7 @@ describe(testName, async () => {
 
       expect(dmId).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -105,7 +104,7 @@ describe(testName, async () => {
       );
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/functional/dms.test.ts
+++ b/functional/dms.test.ts
@@ -97,10 +97,6 @@ describe(testName, async () => {
         convo,
         [workers.get("randomguy")!],
         1,
-        undefined,
-        () => {
-          start = performance.now();
-        },
       );
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {

--- a/functional/groups.test.ts
+++ b/functional/groups.test.ts
@@ -132,10 +132,6 @@ describe(testName, async () => {
           testGroup,
           workers.getWorkers(),
           1,
-          "gm",
-          () => {
-            start = performance.now();
-          },
         );
 
         expect(verifyResult.allReceived).toBe(true);

--- a/functional/groups.test.ts
+++ b/functional/groups.test.ts
@@ -26,7 +26,7 @@ describe(testName, async () => {
   );
   const batchSize = 5;
   const total = 10;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
   // Create a mapping to store group conversations by size
@@ -36,7 +36,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -58,7 +57,7 @@ describe(testName, async () => {
         console.log("Group created", groupsBySize[i].id);
         expect(groupsBySize[i].id).toBeDefined();
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -68,7 +67,7 @@ describe(testName, async () => {
         const members = await groupsBySize[i].members();
         expect(members.length).toBe(i + 1);
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -80,7 +79,7 @@ describe(testName, async () => {
         const name = (groupsBySize[i] as Group).name;
         expect(name).toBe(newName);
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -97,7 +96,7 @@ describe(testName, async () => {
         const members = await groupsBySize[i].members();
         expect(members.length).toBe(previousMembers.length - 1);
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -110,7 +109,7 @@ describe(testName, async () => {
         console.log("GM Message sent in group", groupMessage);
         expect(groupMessage).toBeDefined();
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -141,7 +140,7 @@ describe(testName, async () => {
 
         expect(verifyResult.allReceived).toBe(true);
       } catch (e: unknown) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });

--- a/functional/metadata.test.ts
+++ b/functional/metadata.test.ts
@@ -11,7 +11,7 @@ loadEnv(testName);
 
 describe(testName, async () => {
   let group: Group;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
   const workers = await getWorkers(
@@ -34,7 +34,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;

--- a/functional/offline.test.ts
+++ b/functional/offline.test.ts
@@ -19,7 +19,7 @@ describe(
     let group: Group;
     let workers: WorkerManager;
     workers = await getWorkers(["random1", "random2", "random3"], testName);
-    let hasFailures = false;
+
     let start: number;
     let testStart: number;
     const randomSuffix = Math.random().toString(36).substring(2, 10);
@@ -28,7 +28,6 @@ describe(
       expect,
       workers,
       testName,
-      hasFailuresRef: hasFailures,
       getStart: () => start,
       setStart: (v) => {
         start = v;
@@ -48,7 +47,7 @@ describe(
           );
         console.log("Group created", group.id);
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -138,7 +137,7 @@ describe(
           "order",
         );
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });

--- a/functional/order.test.ts
+++ b/functional/order.test.ts
@@ -14,7 +14,7 @@ loadEnv(testName);
 describe(testName, async () => {
   const amount = 5; // Number of messages to collect per receiver
   let workers: WorkerManager;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
   workers = await getWorkers(
@@ -39,7 +39,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -104,7 +103,7 @@ describe(testName, async () => {
         "order",
       );
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/functional/regression.test.ts
+++ b/functional/regression.test.ts
@@ -1,5 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import generatedInboxes from "@helpers/generated-inboxes.json";
+import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
 import { defaultNames, sdkVersionOptions, sleep } from "@helpers/tests";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -13,75 +14,91 @@ describe(testName, () => {
   const versions = sdkVersionOptions;
 
   it("should create a group conversation with all workers", async () => {
-    let names = defaultNames.slice(0, versions.length);
-    let count = 0;
-    let allNames = [];
-    for (const version of versions.reverse()) {
-      allNames.push(names[count] + "-b-" + version);
-      count++;
+    try {
+      let names = defaultNames.slice(0, versions.length);
+      let count = 0;
+      let allNames = [];
+      for (const version of versions.reverse()) {
+        allNames.push(names[count] + "-b-" + version);
+        count++;
+      }
+      console.log("names", allNames);
+      workers = await getWorkers(allNames, testName);
+      await sleep(1000);
+
+      const allWorkers = workers.getWorkers();
+      const creator = allWorkers[0];
+      const inboxIds = allWorkers
+        .map((worker) => worker.inboxId)
+        .filter((inboxId) => inboxId !== creator?.inboxId);
+      console.log("inboxIds", inboxIds.length);
+      const group = await creator?.client.conversations.newGroup(inboxIds);
+      console.log(`Group created with id ${group?.id}`);
+
+      const verifyResult = await verifyMessageStream(group, allWorkers);
+      console.log("verifyResult", JSON.stringify(verifyResult));
+    } catch (e) {
+      logError(e, expect.getState().currentTestName);
+      throw e;
     }
-    console.log("names", allNames);
-    workers = await getWorkers(allNames, testName);
-    await sleep(1000);
-
-    const allWorkers = workers.getWorkers();
-    const creator = allWorkers[0];
-    const inboxIds = allWorkers
-      .map((worker) => worker.inboxId)
-      .filter((inboxId) => inboxId !== creator?.inboxId);
-    console.log("inboxIds", inboxIds.length);
-    const group = await creator?.client.conversations.newGroup(inboxIds);
-    console.log(`Group created with id ${group?.id}`);
-
-    const verifyResult = await verifyMessageStream(group, allWorkers);
-    console.log("verifyResult", JSON.stringify(verifyResult));
   });
 
   it(`Shoudl test the DB after upgrade`, async () => {
-    for (const version of versions) {
-      workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
-      await sleep(1000);
+    try {
+      for (const version of versions) {
+        workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
+        await sleep(1000);
 
-      const bob = workers.get("bob");
-      const inboxId = generatedInboxes[0].inboxId;
-      console.log(
-        "Upgraded to ",
-        "node-sdk:" + String(bob?.sdkVersion),
-        "node-bindings:" + String(bob?.libXmtpVersion),
-      );
-      let convo;
-      if (version === "47") {
-        // @ts-expect-error: SDK version compatibility issues
-        convo = await bob?.client.conversations.newDmByInboxId(inboxId);
-      } else {
-        convo = await bob?.client.conversations.newDm(inboxId);
+        const bob = workers.get("bob");
+        const inboxId = generatedInboxes[0].inboxId;
+        console.log(
+          "Upgraded to ",
+          "node-sdk:" + String(bob?.sdkVersion),
+          "node-bindings:" + String(bob?.libXmtpVersion),
+        );
+        let convo;
+        if (version === "47") {
+          // @ts-expect-error: SDK version compatibility issues
+          convo = await bob?.client.conversations.newDmByInboxId(inboxId);
+        } else {
+          convo = await bob?.client.conversations.newDm(inboxId);
+        }
+        expect(convo?.id).toBeDefined();
+        await sleep(1000);
       }
-      expect(convo?.id).toBeDefined();
-      await sleep(1000);
+    } catch (e) {
+      logError(e, expect.getState().currentTestName);
+      throw e;
     }
   });
+
   it(`Shoudl test the DB after downgrade`, async () => {
-    for (const version of versions.reverse()) {
-      await sleep(1000);
+    try {
+      for (const version of versions.reverse()) {
+        await sleep(1000);
 
-      workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
+        workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
 
-      const bob = workers.get("bob");
-      const inboxId = generatedInboxes[0].inboxId;
-      console.log(
-        "Downgraded to",
-        "node-sdk:" + String(bob?.sdkVersion),
-        "node-bindings:" + String(bob?.libXmtpVersion),
-      );
-      let convo;
-      if (version === "47") {
-        // @ts-expect-error: SDK version compatibility issues
-        convo = await bob?.client.conversations.newDmByInboxId(inboxId);
-      } else {
-        convo = await bob?.client.conversations.newDm(inboxId);
+        const bob = workers.get("bob");
+        const inboxId = generatedInboxes[0].inboxId;
+        console.log(
+          "Downgraded to ",
+          "node-sdk:" + String(bob?.sdkVersion),
+          "node-bindings:" + String(bob?.libXmtpVersion),
+        );
+        let convo;
+        if (version === "47") {
+          // @ts-expect-error: SDK version compatibility issues
+          convo = await bob?.client.conversations.newDmByInboxId(inboxId);
+        } else {
+          convo = await bob?.client.conversations.newDm(inboxId);
+        }
+        expect(convo?.id).toBeDefined();
+        await sleep(1000);
       }
-      expect(convo?.id).toBeDefined();
-      await sleep(1000);
+    } catch (e) {
+      logError(e, expect.getState().currentTestName);
+      throw e;
     }
   });
 });

--- a/functional/streams.test.ts
+++ b/functional/streams.test.ts
@@ -153,9 +153,9 @@ describe(testName, async () => {
   });
 
   it("verifyConsentStream: manage consent for all members in a group", async () => {
-    workers = await getWorkers(names, testName, typeofStream.Consent);
-
     try {
+      workers = await getWorkers(names, testName, typeofStream.Consent);
+
       const groupConsentSender = createGroupConsentSender(
         workers.getWorkers()[0], // henry is doing the consent update
         group.id, // for this group

--- a/functional/streams.test.ts
+++ b/functional/streams.test.ts
@@ -18,8 +18,6 @@ const testName = "streams";
 loadEnv(testName);
 
 describe(testName, async () => {
-  // Test variables
-  let hasFailures = false;
   let start: number;
   let testStart: number;
   let group: Conversation;
@@ -31,7 +29,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -71,7 +68,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -95,7 +92,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -115,7 +112,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -136,7 +133,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -150,7 +147,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -180,8 +177,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = true;
-      console.error("Test failed:", e);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -26,7 +26,7 @@ The helper modules are designed to be imported and used in test suites:
 
 ```typescript
 import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
-import { sendPerformanceResult, sendTestResults } from "@helpers/datadog";
+import { sendPerformanceResult } from "@helpers/datadog";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream, verifyMessageStreamAll } from "@helpers/streams";
 ```
@@ -68,9 +68,6 @@ The `datadog.ts` module provides utilities for sending metrics and test results 
 ```typescript
 // Initialize Datadog metrics
 initDataDog(testName, envValue, geolocation, apiKey);
-
-// Send test results to Datadog
-sendTestResults(hasFailures, testName);
 
 // Send performance metrics
 sendPerformanceResult(expect, workers, start);
@@ -122,7 +119,7 @@ const logger = createLogger();
 setupPrettyLogs();
 
 // Log test errors and track failures
-const hasFailures = logError(error, expect);
+const logError(error, expect);
 
 // Add file logging capability
 addFileLogging(filename);
@@ -327,9 +324,6 @@ Utilities for sending metrics to Datadog:
 ```typescript
 // Send a metric to Datadog
 sendMetric(metricName, metricValue, tags);
-
-// Send a test result to Datadog
-sendTestResults(hasFailures, testName);
 
 // Send a performance metric to Datadog
 sendPerformanceMetric(metricValue, testName, libXmtpVersion, skipNetworkStats);

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -427,26 +427,6 @@ export function sendMetric(
   }
 }
 
-/**
- * Send test results metrics
- */
-export function sendTestResults(hasFailures: boolean, testName: string): void {
-  if (!state.isInitialized) {
-    console.warn("Datadog metrics not initialized");
-    return;
-  }
-
-  try {
-    const metricValue = hasFailures ? 0 : 1;
-    sendMetric("workflow", metricValue, {
-      workflow: testName,
-      metric_type: "workflow",
-    });
-  } catch (error) {
-    console.error("Error reporting to Datadog:", error);
-  }
-}
-
 // Performance tracking
 /**
  * Send performance metrics for tests

--- a/scripts/deprecated/railway-test.ts
+++ b/scripts/deprecated/railway-test.ts
@@ -1,8 +1,6 @@
 import { execSync } from "child_process";
-import { sendTestResults } from "@helpers/datadog";
 
 function runTests(): void {
-  let hasFailures: boolean = false;
   // Get the test name from command line arguments or use default
   const testName = process.argv[2] || "TS_Performance";
 
@@ -27,19 +25,8 @@ function runTests(): void {
       break;
     } catch (e) {
       console.log(e);
-      if (i === 3) {
-        console.log("Test failed after 3 attempts.");
-        hasFailures = true;
-      } else {
-        console.log("Retrying in 10 seconds...");
-        // Wait 10 seconds before retrying
-        execSync("sleep 10");
-      }
     }
   }
-
-  // Report results to Datadog
-  sendTestResults(hasFailures, testName);
 }
 
 // Run tests when this script is executed

--- a/suites/TS_Delivery/TS_Delivery.test.ts
+++ b/suites/TS_Delivery/TS_Delivery.test.ts
@@ -27,7 +27,7 @@ describe(testName, async () => {
   workers = await getWorkers(receiverAmount, testName, typeofStream.Message);
   let group: Group;
   const randomSuffix = Math.random().toString(36).substring(2, 15);
-  let hasFailures = false;
+
   let start: number;
   let testStart: number;
 
@@ -40,7 +40,7 @@ describe(testName, async () => {
           ...workers.getWorkers().map((p) => p.client.inboxId),
         ]);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -49,7 +49,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v: number) => {
       start = v;
@@ -89,7 +88,7 @@ describe(testName, async () => {
         "order",
       );
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -148,7 +147,7 @@ describe(testName, async () => {
         "order",
       );
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -231,7 +230,7 @@ describe(testName, async () => {
         "order",
       );
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -17,7 +17,7 @@ const gmBotAddress = process.env.GM_BOT_ADDRESS as string;
 describe(testName, async () => {
   let convo: Conversation;
   let workers: WorkerManager;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
   const xmtpTester = new XmtpPlaywright({ headless: false, env: "production" });
@@ -33,7 +33,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -66,7 +65,7 @@ describe(testName, async () => {
       const messagesAfter = await convo.messages();
       expect(messagesAfter.length).toBe(prevMessageCount + 2);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -80,7 +79,7 @@ describe(testName, async () => {
       );
       expect(result).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -92,7 +91,7 @@ describe(testName, async () => {
         gmBotAddress,
       ]);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });

--- a/suites/TS_Large/TS_Large.test.ts
+++ b/suites/TS_Large/TS_Large.test.ts
@@ -22,7 +22,7 @@ describe(testName, async () => {
   const steamsToTest = [typeofStream.None];
   let workers: WorkerManager;
   let start: number;
-  let hasFailures: boolean = false;
+
   let testStart: number;
   let newGroup: Conversation;
 
@@ -44,7 +44,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -77,7 +76,7 @@ describe(testName, async () => {
           createTimeMs: (summaryMap[i]?.createTimeMs ?? 0 + creationTimeMs) / 2,
         };
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -99,7 +98,7 @@ describe(testName, async () => {
             `Successfully added ${workersInboxIds.length} members to the group`,
           );
         } catch (e) {
-          hasFailures = logError(e, expect.getState().currentTestName);
+          logError(e, expect.getState().currentTestName);
           throw e;
         }
       });
@@ -132,7 +131,7 @@ describe(testName, async () => {
             conversationStreamTimeMs: streamTimeMs,
           };
         } catch (e) {
-          hasFailures = logError(e, expect.getState().currentTestName);
+          logError(e, expect.getState().currentTestName);
           throw e;
         }
       });
@@ -167,7 +166,7 @@ describe(testName, async () => {
             groupUpdatedStreamTimeMs: streamTimeMs,
           };
         } catch (e) {
-          hasFailures = logError(e, expect.getState().currentTestName);
+          logError(e, expect.getState().currentTestName);
           throw e;
         }
       });
@@ -202,7 +201,7 @@ describe(testName, async () => {
 
           expect(verifyResult.allReceived).toBe(true);
         } catch (e) {
-          hasFailures = logError(e, expect.getState().currentTestName);
+          logError(e, expect.getState().currentTestName);
           throw e;
         }
       });
@@ -221,7 +220,7 @@ describe(testName, async () => {
             syncTimeMs: (summaryMap[i]?.syncTimeMs ?? 0 + syncTimeMs) / 2,
           };
         } catch (e) {
-          hasFailures = logError(e, expect.getState().currentTestName);
+          logError(e, expect.getState().currentTestName);
           throw e;
         }
       });

--- a/suites/TS_Large/TS_lSyncs.test.ts
+++ b/suites/TS_Large/TS_lSyncs.test.ts
@@ -1,0 +1,265 @@
+import { loadEnv } from "@helpers/client";
+import generatedInboxes from "@helpers/generated-inboxes.json";
+import { logError } from "@helpers/logger";
+import {
+  verifyConversationGroupStream,
+  verifyGroupUpdateStream,
+  verifyMessageStream,
+} from "@helpers/streams";
+import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
+import { getWorkers, type WorkerManager } from "@workers/manager";
+import { type Conversation, type Group } from "@xmtp/node-sdk";
+import { afterAll, describe, expect, it } from "vitest";
+
+const testName = "TS_Large_Syncs";
+loadEnv(testName);
+
+describe(testName, async () => {
+  const workersCount = 5;
+  const batchSize = 50;
+  const total = 400;
+  const steamsToTest = [typeofStream.None];
+  let workers: WorkerManager;
+  let start: number;
+
+  let testStart: number;
+  let newGroup: Conversation;
+
+  // Hold timing metrics per group size
+  interface SummaryEntry {
+    groupSize: number;
+    messageStreamTimeMs?: number;
+    groupUpdatedStreamTimeMs?: number;
+    conversationStreamTimeMs?: number;
+    syncTimeMs?: number;
+    createTimeMs?: number;
+  }
+
+  const summaryMap: Record<number, SummaryEntry> = {};
+
+  workers = await getWorkers(workersCount, testName, steamsToTest[0]);
+
+  setupTestLifecycle({
+    expect,
+    workers,
+    testName,
+    getStart: () => start,
+    setStart: (v) => {
+      start = v;
+    },
+    getTestStart: () => testStart,
+    setTestStart: (v) => {
+      testStart = v;
+    },
+  });
+
+  for (let i = batchSize; i <= total; i += batchSize) {
+    it(`createLargeGroup-${i}: should create a large group of ${i} participants ${i}`, async () => {
+      try {
+        console.log(`Creating group with ${i} participants`);
+        const sliced = generatedInboxes.slice(0, i);
+
+        // Measure creation time
+        const createStart = performance.now();
+        newGroup = await workers
+          .getWorkers()[0]
+          .client.conversations.newGroup(sliced.map((inbox) => inbox.inboxId));
+        const creationTimeMs = performance.now() - createStart;
+
+        expect(newGroup.id).toBeDefined();
+        console.log(
+          `Created group with ${i} participants in ${creationTimeMs.toFixed(2)}ms`,
+        );
+        summaryMap[i] = {
+          ...(summaryMap[i] ?? { groupSize: i }),
+          createTimeMs: (summaryMap[i]?.createTimeMs ?? 0 + creationTimeMs) / 2,
+        };
+      } catch (e) {
+        logError(e, expect.getState().currentTestName);
+        throw e;
+      }
+    });
+
+    if (
+      steamsToTest.includes(typeofStream.Message) ||
+      steamsToTest.includes(typeofStream.GroupUpdated) ||
+      steamsToTest.includes(typeofStream.None)
+    ) {
+      it(`addMembers-${i}: should add members to group`, async () => {
+        try {
+          console.log("Adding members to group");
+          const workersInboxIds = workers
+            .getWorkers()
+            .map((worker) => worker.inboxId);
+
+          await (newGroup as Group).addMembers(workersInboxIds);
+          console.log(
+            `Successfully added ${workersInboxIds.length} members to the group`,
+          );
+        } catch (e) {
+          logError(e, expect.getState().currentTestName);
+          throw e;
+        }
+      });
+    }
+
+    if (steamsToTest.includes(typeofStream.Conversation)) {
+      it(`verifyLargeConversationStream-${i}: should create a new conversation`, async () => {
+        try {
+          console.log("Testing conversation stream with new DM creation");
+
+          // Use the dedicated conversation stream verification helper
+          const verifyResult = await verifyConversationGroupStream(
+            newGroup as Group,
+            workers.getWorkers(),
+            () => {
+              start = performance.now();
+            },
+          );
+
+          const streamTimeMs = performance.now() - start;
+          console.log(
+            `Conversation stream verification for ${i} participants took ${streamTimeMs.toFixed(2)}ms`,
+          );
+
+          expect(verifyResult.allReceived).toBe(true);
+
+          // Save metrics
+          summaryMap[i] = {
+            ...(summaryMap[i] ?? { groupSize: i }),
+            conversationStreamTimeMs: streamTimeMs,
+          };
+        } catch (e) {
+          logError(e, expect.getState().currentTestName);
+          throw e;
+        }
+      });
+    } else if (steamsToTest.includes(typeofStream.GroupUpdated)) {
+      it(`verifyLargeGroupMetadataStream-${i}: should update group name`, async () => {
+        try {
+          workers = await getWorkers(
+            workersCount,
+            testName,
+            typeofStream.GroupUpdated,
+          );
+          const verifyResult = await verifyGroupUpdateStream(
+            newGroup as Group,
+            workers.getWorkers(),
+            1,
+            undefined,
+            () => {
+              start = performance.now();
+            },
+          );
+
+          const streamTimeMs = performance.now() - start;
+          console.log(
+            `Group metadata update stream for ${i} participants took ${streamTimeMs.toFixed(2)}ms`,
+          );
+
+          expect(verifyResult.allReceived).toBe(true);
+
+          // Save metrics
+          summaryMap[i] = {
+            ...(summaryMap[i] ?? { groupSize: i }),
+            groupUpdatedStreamTimeMs: streamTimeMs,
+          };
+        } catch (e) {
+          logError(e, expect.getState().currentTestName);
+          throw e;
+        }
+      });
+    } else if (steamsToTest.includes(typeofStream.Message)) {
+      it(`receiveLargeGroupMessage-${i}: should create a group and measure all streams`, async () => {
+        try {
+          workers = await getWorkers(
+            workersCount,
+            testName,
+            typeofStream.Message,
+          );
+          const verifyResult = await verifyMessageStream(
+            newGroup,
+            workers.getWorkers(),
+            1,
+            "gm",
+            () => {
+              start = performance.now();
+            },
+          );
+
+          const streamTimeMs = performance.now() - start;
+          console.log(
+            `Message stream for ${i} participants took ${streamTimeMs.toFixed(2)}ms`,
+          );
+
+          // Save metrics
+          summaryMap[i] = {
+            ...(summaryMap[i] ?? { groupSize: i }),
+            messageStreamTimeMs: streamTimeMs,
+          };
+
+          expect(verifyResult.allReceived).toBe(true);
+        } catch (e) {
+          logError(e, expect.getState().currentTestName);
+          throw e;
+        }
+      });
+    } else if (steamsToTest.includes(typeofStream.None)) {
+      it(`verifySyncAll-${i}: should verify all streams and measure sync time per worker`, async () => {
+        try {
+          const syncStart = performance.now();
+          for (const worker of workers.getWorkers()) {
+            await worker.client.conversations.sync();
+          }
+          const syncTimeMs = performance.now() - syncStart;
+
+          // Save metrics
+          summaryMap[i] = {
+            ...(summaryMap[i] ?? { groupSize: i }),
+            syncTimeMs: (summaryMap[i]?.syncTimeMs ?? 0 + syncTimeMs) / 2,
+          };
+        } catch (e) {
+          logError(e, expect.getState().currentTestName);
+          throw e;
+        }
+      });
+    }
+  }
+
+  // After all tests have run, output a concise summary of all timings per group size
+  afterAll(() => {
+    if (Object.keys(summaryMap).length === 0) {
+      console.log("No timing data was collected.");
+      return;
+    }
+
+    const sorted = Object.values(summaryMap).sort(
+      (a, b) => a.groupSize - b.groupSize,
+    );
+
+    console.log("\n===== Timing Summary per Group Size =====");
+    for (const entry of sorted) {
+      const {
+        groupSize,
+        messageStreamTimeMs,
+        groupUpdatedStreamTimeMs,
+        conversationStreamTimeMs,
+      } = entry;
+
+      console.log(
+        `Group ${groupSize} → ` +
+          (messageStreamTimeMs !== undefined
+            ? `Message: ${messageStreamTimeMs.toFixed(2)} ms; `
+            : "") +
+          (groupUpdatedStreamTimeMs !== undefined
+            ? `GroupUpdated: ${groupUpdatedStreamTimeMs.toFixed(2)} ms; `
+            : "") +
+          (conversationStreamTimeMs !== undefined
+            ? `Conversation: ${conversationStreamTimeMs.toFixed(2)} ms; `
+            : ""),
+      );
+    }
+    console.log("==========================================\n");
+  });
+});

--- a/suites/TS_Performance/TS_Performance.test.ts
+++ b/suites/TS_Performance/TS_Performance.test.ts
@@ -27,7 +27,7 @@ describe(testName, async () => {
   let dm: Conversation;
   let workers: WorkerManager;
   let start: number;
-  let hasFailures: boolean = false;
+
   let testStart: number;
 
   workers = await getWorkers(
@@ -41,7 +41,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;
@@ -57,7 +56,7 @@ describe(testName, async () => {
       const client = await getWorkers(["randomclient"], testName);
       expect(client).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -87,7 +86,7 @@ describe(testName, async () => {
       );
       expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -98,7 +97,7 @@ describe(testName, async () => {
         .client.preferences.inboxState(true);
       expect(inboxState.installations.length).toBeGreaterThan(0);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -111,7 +110,7 @@ describe(testName, async () => {
       expect(dm).toBeDefined();
       expect(dm.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -127,7 +126,7 @@ describe(testName, async () => {
       expect(dm2).toBeDefined();
       expect(dm2.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -141,7 +140,7 @@ describe(testName, async () => {
 
       expect(dmId).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -160,7 +159,7 @@ describe(testName, async () => {
 
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -178,7 +177,7 @@ describe(testName, async () => {
       console.log("New group created", newGroup.id);
       expect(newGroup.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -195,7 +194,7 @@ describe(testName, async () => {
         );
       expect(newGroupByIdentifier.id).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -205,7 +204,7 @@ describe(testName, async () => {
       const members = await newGroup.members();
       expect(members.length).toBe(members.length);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -217,7 +216,7 @@ describe(testName, async () => {
       const name = (newGroup as Group).name;
       expect(name).toBe(newName);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -230,7 +229,7 @@ describe(testName, async () => {
       console.log("GM Message sent in group", groupMessage);
       expect(groupMessage).toBeDefined();
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -247,7 +246,7 @@ describe(testName, async () => {
       );
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -255,7 +254,7 @@ describe(testName, async () => {
     try {
       await (newGroup as Group).addMembers([workers.getWorkers()[2].inboxId]);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -271,7 +270,7 @@ describe(testName, async () => {
       const members = await newGroup.members();
       expect(members.length).toBe(previousMembers.length - 1);
     } catch (e) {
-      hasFailures = logError(e, expect.getState().currentTestName);
+      logError(e, expect.getState().currentTestName);
       throw e;
     }
   });
@@ -289,7 +288,7 @@ describe(testName, async () => {
           ]);
         expect(newGroup.id).toBeDefined();
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -306,7 +305,7 @@ describe(testName, async () => {
           );
         expect(newGroupByIdentifier.id).toBeDefined();
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -316,7 +315,7 @@ describe(testName, async () => {
         const members = await newGroup.members();
         expect(members.length).toBe(members.length);
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -328,7 +327,7 @@ describe(testName, async () => {
         const name = (newGroup as Group).name;
         expect(name).toBe(newName);
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -344,7 +343,7 @@ describe(testName, async () => {
         const members = await newGroup.members();
         expect(members.length).toBe(previousMembers.length - 1);
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -357,7 +356,7 @@ describe(testName, async () => {
         console.log("GM Message sent in group", groupMessage);
         expect(groupMessage).toBeDefined();
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });
@@ -374,7 +373,7 @@ describe(testName, async () => {
         );
         expect(verifyResult.allReceived).toBe(true);
       } catch (e) {
-        hasFailures = logError(e, expect.getState().currentTestName);
+        logError(e, expect.getState().currentTestName);
         throw e;
       }
     });

--- a/suites/TS_Stress/TS_Stress.test.ts
+++ b/suites/TS_Stress/TS_Stress.test.ts
@@ -31,7 +31,7 @@ describe(testName, async () => {
   let bot: Worker;
   let client: Client;
   let conversation: Conversation;
-  let hasFailures: boolean = false;
+
   let start: number;
   let testStart: number;
 
@@ -53,7 +53,6 @@ describe(testName, async () => {
     expect,
     workers,
     testName,
-    hasFailuresRef: hasFailures,
     getStart: () => start,
     setStart: (v) => {
       start = v;


### PR DESCRIPTION
### Remove test failure tracking logic and Datadog reporting from test infrastructure to simplify error handling
* Removes the `hasFailures` tracking variable and associated logic from all test files, simplifying error handling to use direct `logError` calls
* Removes the `sendTestResults` function from [datadog.ts](https://github.com/xmtp/xmtp-qa-testing/pull/240/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3), eliminating Datadog test result reporting
* Updates test lifecycle setup in [vitest.ts](https://github.com/xmtp/xmtp-qa-testing/pull/240/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) to remove failure tracking parameters and error handling
* Modifies `verifyMessageStream` function calls across test files to remove unnecessary parameters
* Removes version information collection steps from multiple GitHub workflow files
* Improves error handling in [regression.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/240/files#diff-8965f8a922000639ab7249eb71952d9f73f3c546d742fcf7845ecfc43f3405a8) with proper try/catch blocks and group creation logic

#### 📍Where to Start
Start with the core changes to test infrastructure in [vitest.ts](https://github.com/xmtp/xmtp-qa-testing/pull/240/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) which removes the `hasFailuresRef` parameter from the `setupTestLifecycle` function and modifies the test lifecycle hooks.

----

_[Macroscope](https://app.macroscope.com) summarized 3a05b00._