### PR TITLE
Refactor test lifecycle to support custom duration tracking

### DIFF
--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -232,8 +232,6 @@ export async function verifyMessageStream(
 }
 
 const filterReceivers = async (group: Group, participants: Worker[]) => {
-  console.log("Waiting for 1 second before starting stream");
-
   const creatorId = (await group.metadata()).creatorInboxId;
   return participants.filter((p) => p.client?.inboxId !== creatorId);
 };

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -39,7 +39,6 @@ export const setupTestLifecycle = ({
       }
     }
     void sendPerformanceMetric(duration, testName, libXmtpVersion, false);
-    setStart(0);
     if (setCustomDuration) setCustomDuration(undefined); // Reset after each test if available
   });
 

--- a/suites/TS_Large/ts_large_conversations.test.ts
+++ b/suites/TS_Large/ts_large_conversations.test.ts
@@ -34,6 +34,11 @@ describe(testName, async () => {
     steamsToTest,
   );
 
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+
   setupTestLifecycle({
     expect,
     workers,
@@ -41,6 +46,10 @@ describe(testName, async () => {
     getStart: () => start,
     setStart: (v) => {
       start = v;
+    },
+    getCustomDuration: () => customDuration,
+    setCustomDuration: (v) => {
+      customDuration = v;
     },
   });
 
@@ -58,7 +67,7 @@ describe(testName, async () => {
           workers.getWorkers(),
         );
 
-        start = verifyResult.averageEventTiming;
+        setCustomDuration(verifyResult.averageEventTiming);
         expect(verifyResult.allReceived).toBe(true);
 
         // Save metrics

--- a/suites/TS_Large/ts_large_messages.test.ts
+++ b/suites/TS_Large/ts_large_messages.test.ts
@@ -34,6 +34,11 @@ describe(testName, async () => {
     steamsToTest,
   );
 
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+
   setupTestLifecycle({
     expect,
     workers,
@@ -41,6 +46,10 @@ describe(testName, async () => {
     getStart: () => start,
     setStart: (v) => {
       start = v;
+    },
+    getCustomDuration: () => customDuration,
+    setCustomDuration: (v) => {
+      customDuration = v;
     },
   });
 
@@ -64,7 +73,7 @@ describe(testName, async () => {
           messageStreamTimeMs: verifyResult.averageEventTiming,
         };
 
-        start = verifyResult.averageEventTiming;
+        setCustomDuration(verifyResult.averageEventTiming);
         expect(verifyResult.allReceived).toBe(true);
       } catch (e) {
         logError(e, expect.getState().currentTestName);

--- a/suites/TS_Large/ts_large_metadata.test.ts
+++ b/suites/TS_Large/ts_large_metadata.test.ts
@@ -34,6 +34,11 @@ describe(testName, async () => {
     steamsToTest,
   );
 
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+
   setupTestLifecycle({
     expect,
     workers,
@@ -42,8 +47,11 @@ describe(testName, async () => {
     setStart: (v) => {
       start = v;
     },
+    getCustomDuration: () => customDuration,
+    setCustomDuration: (v) => {
+      customDuration = v;
+    },
   });
-
   for (
     let i = TS_LARGE_BATCH_SIZE;
     i <= TS_LARGE_TOTAL;
@@ -58,7 +66,7 @@ describe(testName, async () => {
           undefined,
         );
 
-        start = verifyResult.averageEventTiming;
+        setCustomDuration(verifyResult.averageEventTiming);
         expect(verifyResult.allReceived).toBe(true);
 
         // Save metrics

--- a/suites/TS_Performance/TS_Performance.test.ts
+++ b/suites/TS_Performance/TS_Performance.test.ts
@@ -28,6 +28,11 @@ describe(testName, async () => {
   let dm: Conversation;
   let workers: WorkerManager;
   let start: number;
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+  const getCustomDuration = () => customDuration;
 
   workers = await getWorkers(
     getRandomNames(10),
@@ -43,6 +48,8 @@ describe(testName, async () => {
     setStart: (v: number) => {
       start = v;
     },
+    getCustomDuration,
+    setCustomDuration,
   });
 
   it("clientCreate: should measure creating a client", async () => {
@@ -140,7 +147,7 @@ describe(testName, async () => {
       const verifyResult = await verifyMessageStream(dm, [
         workers.getWorkers()[1],
       ]);
-      start = verifyResult.averageEventTiming;
+      setCustomDuration(verifyResult.averageEventTiming);
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
       logError(e, expect.getState().currentTestName);
@@ -223,7 +230,7 @@ describe(testName, async () => {
         newGroup,
         workers.getWorkers(),
       );
-      start = verifyResult.averageEventTiming;
+      setCustomDuration(verifyResult.averageEventTiming);
       expect(verifyResult.allReceived).toBe(true);
     } catch (e) {
       logError(e, expect.getState().currentTestName);
@@ -346,7 +353,7 @@ describe(testName, async () => {
           newGroup,
           workers.getWorkers(),
         );
-        start = verifyResult.averageEventTiming;
+        setCustomDuration(verifyResult.averageEventTiming);
         expect(verifyResult.allReceived).toBe(true);
       } catch (e) {
         logError(e, expect.getState().currentTestName);

--- a/suites/TS_Performance/TS_Performance.test.ts
+++ b/suites/TS_Performance/TS_Performance.test.ts
@@ -28,11 +28,6 @@ describe(testName, async () => {
   let dm: Conversation;
   let workers: WorkerManager;
   let start: number;
-  let customDuration: number | undefined = undefined;
-  const setCustomDuration = (duration: number | undefined) => {
-    customDuration = duration;
-  };
-  const getCustomDuration = () => customDuration;
 
   workers = await getWorkers(
     getRandomNames(10),
@@ -40,16 +35,23 @@ describe(testName, async () => {
     typeofStream.Message,
   );
 
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+
   setupTestLifecycle({
     expect,
     workers,
     testName,
     getStart: () => start,
-    setStart: (v: number) => {
+    setStart: (v) => {
       start = v;
     },
-    getCustomDuration,
-    setCustomDuration,
+    getCustomDuration: () => customDuration,
+    setCustomDuration: (v) => {
+      customDuration = v;
+    },
   });
 
   it("clientCreate: should measure creating a client", async () => {


### PR DESCRIPTION
### Add custom duration tracking support to test lifecycle for more accurate performance measurement in test suites
Introduces custom duration tracking capabilities in the test lifecycle setup through modifications to [vitest.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4). The changes allow tests to override automatically calculated durations with custom values via new `getCustomDuration` and `setCustomDuration` parameters. Multiple test suites have been updated to use this new functionality:

* [ts_large_conversations.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-e487faae27b3854043af75ac0f47fdc827a8c318d2568d686032402d7dc959ea), [ts_large_messages.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-8c70a0046c756f08f3e0a1971f1a96268feaedfa8b2fdb41f7648cb3580fdbd8), and [ts_large_metadata.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-135277056b6e36871b56d2cccf0aea9614bf4c4009332c14cda9f0a2649c6de7) now use `setCustomDuration` to record `averageEventTiming` from verification results
* [TS_Performance.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-716e1ec0f3e907f24d321016214c7c7a880de303b1c5e07570a8de8866237720) implements custom duration tracking across multiple test cases
* Removes debug logging from `filterReceivers` function in [streams.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a)

#### 📍Where to Start
Start with the `setupTestLifecycle` function in [vitest.ts](https://github.com/xmtp/xmtp-qa-testing/pull/245/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) which contains the core changes for custom duration tracking implementation.

----

_[Macroscope](https://app.macroscope.com) summarized 3ec2473._