### PR TITLE
Update performance metrics for group operations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,61 +135,45 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 </div>
 
-### Group Creation & SyncAll Performance
+### Group operations performance
+
+#### Sender-Side Performance Metrics by Group Size
 
 <div style="overflow-x: auto;">
 
-| Size | Create(ms) | SyncAll(ms) | Status                 |
-| ---- | ---------- | ----------- | ---------------------- |
-| 50   | 1453.51    | 65.37       | ✅ On Target           |
-| 100  | 1935.67    | 443.56      | ✅ On Target           |
-| 150  | 2556.97    | 622.56      | ✅ On Target           |
-| 200  | 3512.65    | 785.11      | ⚠️ Performance Concern |
-| 250  | 4787.85    | 1164.93     | ⚠️ Performance Concern |
-| 300  | 6010.43    | 1249.18     | ⚠️ Performance Concern |
-| 350  | 6294.62    | 2298.25     | ⚠️ Performance Concern |
-| 400  | 7015.99    | 2700.66     | ⚠️ Performance Concern |
+| Size | Send message (ms) | Update name (ms) | Remove members (ms) | Create (ms) | Status                 |
+| ---- | ----------------- | ---------------- | ------------------- | ----------- | ---------------------- |
+| 50   | 86.01             | 135.36           | 138.57              | 1329.20     | ✅ On Target           |
+| 100  | 88.41             | 144.67           | 156.86              | 1522.13     | ✅ On Target           |
+| 150  | 94.55             | 202.64           | 189.81              | 2306.10     | ✅ On Target           |
+| 200  | 93.42             | 193.36           | 204.78              | 3343.84     | ✅ On Target           |
+| 250  | 107.76            | 219.17           | 236.53              | 4276.19     | ⚠️ Performance Concern |
+| 300  | 97.09             | 244.24           | 247.22              | 5462.81     | ⚠️ Performance Concern |
+| 350  | 101.34            | 263.91           | 308.01              | 6640.68     | ⚠️ Performance Concern |
+| 400  | 111.34            | 280.00           | 320.00              | 7640.68     | ⚠️ Performance Concern |
+
+</div>
+
+_Note: This measurments are taken only from the sender side with open streams._
+
+#### Receiver-Side Average Timing Metrics by Group Size (in milliseconds)
+
+<div style="overflow-x: auto;">
+
+| Group Size | Sync    | New Members | Metadata | Messages | Status                 |
+| ---------- | ------- | ----------- | -------- | -------- | ---------------------- |
+| 50         | 123.31  | 687.30      | 141.60   | 131.50   | ✅ On Target           |
+| 100        | 615.72  | 746.10      | 155.40   | 117.00   | ✅ On Target           |
+| 150        | 798.83  | 833.60      | 163.70   | 147.20   | ✅ On Target           |
+| 200        | 1039.06 | 953.70      | 179.10   | 173.90   | ✅ On Target           |
+| 250        | 1285.81 | 1007.90     | 187.80   | 161.70   | ⚠️ Performance Concern |
+| 300        | 1514.04 | 1040.90     | 195.67   | 167.70   | ⚠️ Performance Concern |
+| 350        | 1711.04 | 1042.10     | 198.00   | 178.10   | ⚠️ Performance Concern |
+| 400        | 2514.95 | 1192.10     | 214.17   | 173.60   | ⚠️ Performance Concern |
 
 </div>
 
 _Note: `syncAll` is measured only as the first cold start of the client (fresh inbox)._
-
-### Other Group Operations Performance
-
-<div style="overflow-x: auto;">
-
-| Size | Send message (ms) | Update name (ms) | Remove members (ms) | Status       |
-| ---- | ----------------- | ---------------- | ------------------- | ------------ |
-| 50   | 86.01             | 135.36           | 138.57              | ✅ On Target |
-| 100  | 88.41             | 144.67           | 156.86              | ✅ On Target |
-| 150  | 94.55             | 202.64           | 189.81              | ✅ On Target |
-| 200  | 93.42             | 193.36           | 204.78              | ✅ On Target |
-| 250  | 107.76            | 219.17           | 236.53              | ✅ On Target |
-| 300  | 97.09             | 244.24           | 247.22              | ✅ On Target |
-| 400  | 101.34            | 263.91           | 308.01              | ✅ On Target |
-
-</div>
-
-_Note: This measurments are taken only from the sender side._
-
-### Group stream performance
-
-<div style="overflow-x: auto;">
-
-| Size | Receive message (ms) | New name metadata (ms) | New added members (ms) | Status                 |
-| ---- | -------------------- | ---------------------- | ---------------------- | ---------------------- |
-| 50   | 58.00                | 87.75                  | 927.00                 | ⚠️ Performance Concern |
-| 100  | 56.00                | 107.75                 | 1056.00                | ⚠️ Performance Concern |
-| 150  | 72.25                | 110.00                 | 1161.00                | ⚠️ Performance Concern |
-| 200  | 93.00                | 129.00                 | 1425.00                | ⚠️ Performance Concern |
-| 250  | 89.50                | 143.75                 | 1481.00                | ⚠️ Performance Concern |
-| 300  | 85.00                | 173.25                 | 1513.00                | ⚠️ Performance Concern |
-| 350  | 120.50               | 191.75                 | 1523.00                | ⚠️ Performance Concern |
-| 400  | 140.00               | 203.25                 | 1546.00                | ⚠️ Performance Concern |
-
-</div>
-
-_Note: This measurements are taken only from the receiver side (fresh inbox) and type of stream at the time of testing._
 
 ## Networks performance
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,7 @@ _Note: This measurments are taken only from the sender side with open streams._
 
 </div>
 
-_Note: `syncAll` is measured only as the first cold start of the client (fresh inbox)._
-_Note: Except for `syncAll` the rest measurements are taken from the stream performance._
+_Note: Except for `syncAll` the rest measurements are taken from the stream performance. `syncAll` is measured only as the first cold start of the client (fresh inbox)._
 
 ## Networks performance
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 ### Group operations performance
 
-#### Sender-Side Performance Metrics by Group Size
+#### Sender-Side average performance
 
 <div style="overflow-x: auto;">
 
@@ -156,7 +156,7 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 _Note: This measurments are taken only from the sender side with open streams._
 
-#### Receiver-Side Average Timing Metrics by Group Size (in milliseconds)
+#### Receiver-Side average performance
 
 <div style="overflow-x: auto;">
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ _Note: This measurments are taken only from the sender side with open streams._
 </div>
 
 _Note: `syncAll` is measured only as the first cold start of the client (fresh inbox)._
-_Note: Exceptions are `syncAll` the rest meadure the stream performance._
+_Note: Except for `syncAll` the rest measurements are taken from the stream performance._
 
 ## Networks performance
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 </div>
 
-_Note: This measurments are taken only from the sender side with open streams._
+_Note: This measurments are taken only from the sender side and after the group is created._
 
 #### Receiver-Side average performance
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ _Note: This measurments are taken only from the sender side with open streams._
 
 <div style="overflow-x: auto;">
 
-| Group Size | Sync    | New Members | Metadata | Messages | Status                 |
+| Group Size | SyncAll | New Members | Metadata | Messages | Status                 |
 | ---------- | ------- | ----------- | -------- | -------- | ---------------------- |
 | 50         | 123.31  | 687.30      | 141.60   | 131.50   | ✅ On Target           |
 | 100        | 615.72  | 746.10      | 155.40   | 117.00   | ✅ On Target           |
@@ -174,6 +174,7 @@ _Note: This measurments are taken only from the sender side with open streams._
 </div>
 
 _Note: `syncAll` is measured only as the first cold start of the client (fresh inbox)._
+_Note: Exceptions are `syncAll` the rest meadure the stream performance._
 
 ## Networks performance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-testing",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
### Reorganize performance metrics documentation for group operations in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/250/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to improve clarity
The documentation for group operation performance metrics has been restructured into two main categories: sender-side and receiver-side performance tables. The changes consolidate previously separate sections into a unified "Group operations performance" section in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/250/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), with updated explanatory notes and measurement conditions for each metric category.

#### 📍Where to Start
Start with the "Group operations performance" section in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/250/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) which contains the consolidated performance metrics tables and explanatory notes.

----

_[Macroscope](https://app.macroscope.com) summarized 08ed131._