### PR TITLE
Add pull request trigger and increase stream timeout

### DIFF
--- a/.github/workflows/TS_Agents.yml
+++ b/.github/workflows/TS_Agents.yml
@@ -2,6 +2,9 @@ name: TS_Agents
 description: "should verify health of agents"
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "10 * * * *" # Runs at 10 minutes past each hour
   workflow_dispatch:
@@ -23,6 +26,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       WALLET_KEY: ${{ secrets.WALLET_KEY }}
+      DEFAULT_STREAM_TIMEOUT_MS: 6000
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
     steps:

--- a/.github/workflows/TS_Agents.yml
+++ b/.github/workflows/TS_Agents.yml
@@ -2,9 +2,6 @@ name: TS_Agents
 description: "should verify health of agents"
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "10 * * * *" # Runs at 10 minutes past each hour
   workflow_dispatch:
@@ -21,8 +18,6 @@ jobs:
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      DELIVERY_AMOUNT: ${{ vars.DELIVERY_AMOUNT }}
-      DELIVERY_RECEIVERS: ${{ vars.DELIVERY_RECEIVERS }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       WALLET_KEY: ${{ secrets.WALLET_KEY }}

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -13,7 +13,8 @@ import {
 import type { WorkerBase } from "./manager";
 
 // Default timeout for stream collection in milliseconds
-const DEFAULT_STREAM_TIMEOUT_MS = defaultValues.streamTimeout; // 3 seconds
+const DEFAULT_STREAM_TIMEOUT_MS =
+  process.env.DEFAULT_STREAM_TIMEOUT_MS || defaultValues.streamTimeout; // 6 seconds
 
 export enum typeOfResponse {
   Gm = "gm",

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -13,8 +13,9 @@ import {
 import type { WorkerBase } from "./manager";
 
 // Default timeout for stream collection in milliseconds
-const DEFAULT_STREAM_TIMEOUT_MS =
-  process.env.DEFAULT_STREAM_TIMEOUT_MS || defaultValues.streamTimeout; // 6 seconds
+const DEFAULT_STREAM_TIMEOUT_MS = process.env.DEFAULT_STREAM_TIMEOUT_MS
+  ? parseInt(process.env.DEFAULT_STREAM_TIMEOUT_MS)
+  : defaultValues.streamTimeout; // 3 seconds
 
 export enum typeOfResponse {
   Gm = "gm",


### PR DESCRIPTION
### Configure TS_Agents workflow to run on pull requests and increase stream timeout to 6000ms
* Add pull request trigger to [TS_Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/261/files#diff-351a6cc0e86290661b4df80ef188870cd553b6e83443d2be332629fcc9b591cb) workflow for PRs targeting the main branch
* Modify stream timeout handling in [main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/261/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) to read `DEFAULT_STREAM_TIMEOUT_MS` from environment variables with a fallback to default value

#### 📍Where to Start
Start with the workflow configuration changes in [TS_Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/261/files#diff-351a6cc0e86290661b4df80ef188870cd553b6e83443d2be332629fcc9b591cb) to understand the trigger and environment variable additions.

----

_[Macroscope](https://app.macroscope.com) summarized 9618500._