### PR TITLE
Allow tests to run in headless mode for CI efficiency

### DIFF
--- a/.github/workflows/TS_Gm.yml
+++ b/.github/workflows/TS_Gm.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [production]
+        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}

--- a/.github/workflows/TS_Gm.yml
+++ b/.github/workflows/TS_Gm.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [dev, production]
+        environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}

--- a/helpers/slack.ts
+++ b/helpers/slack.ts
@@ -54,9 +54,15 @@ if (!testName) {
 const branchName = githubRef.replace("refs/heads/", "");
 console.debug(`Current branch: ${branchName}`);
 
-// Only proceed with notification if it's an error
-if (jobStatus === "success" || jobStatus === "passed") {
-  console.debug(`Job status is ${jobStatus}. No need to send notification.`);
+// Only proceed with notification if it's an error and on the main branch
+if (
+  jobStatus === "success" ||
+  jobStatus === "passed" ||
+  branchName !== "main"
+) {
+  console.debug(
+    `Skipping notification: job status is ${jobStatus} or not on main branch (${branchName}).`,
+  );
   process.exit(0);
 }
 

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -18,7 +18,7 @@ describe(testName, () => {
   let convo: Conversation;
   let workers: WorkerManager;
 
-  const xmtpTester = new XmtpPlaywright({ headless: false, env: "production" });
+  const xmtpTester = new XmtpPlaywright({ headless: true, env: "production" });
   beforeAll(async () => {
     await xmtpTester.startPage();
     workers = await getWorkers(


### PR DESCRIPTION
### Modify Slack notification logic and test implementation to enable headless CI testing
* Updates notification logic in [slack.ts](https://github.com/xmtp/xmtp-qa-testing/pull/262/files#diff-ebe05a574424518c32bb3ca2d9b43580e3107d04a0d418d482b69c132388d4ff) to only trigger for failed jobs on the `main` branch
* Refactors test implementation in [TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/262/files#diff-5bd618685ddc44cad0b8d171e3a6f352b19a9894c11abfd6a1930c4e4f735a56) to use `verifyDmStream` helper function instead of manual message verification, and changes worker response type from `Gm` to `None`

#### 📍Where to Start
Start with the notification logic changes in [slack.ts](https://github.com/xmtp/xmtp-qa-testing/pull/262/files#diff-ebe05a574424518c32bb3ca2d9b43580e3107d04a0d418d482b69c132388d4ff) as it contains the core changes to the notification behavior.

----

_[Macroscope](https://app.macroscope.com) summarized 4ffb088._