### PR TITLE
Refactor address input handling for better readability

### DIFF
--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -77,12 +77,15 @@ export class XmtpPlaywright {
 
     await this.page.getByRole("button", { name: "Members" }).click();
 
+    const addressInput = this.page.getByRole("textbox", { name: "Address" });
     for (const address of addresses) {
-      await this.page.getByRole("textbox", { name: "Address" }).fill(address);
+      await addressInput.fill(address);
       await this.page.getByRole("button", { name: "Add" }).click();
     }
 
     await this.page.getByRole("button", { name: "Create" }).click();
+    await addressInput.waitFor({ state: "hidden" });
+    return;
   }
 
   /**
@@ -114,6 +117,8 @@ export class XmtpPlaywright {
       name: "Type a message...",
     });
     await messageInput.waitFor({ state: "visible" });
+    //Important to wait for the page to load the message input
+    await this.page.waitForTimeout(1000);
 
     console.debug("Filling message");
     await messageInput.fill(message);

--- a/suites/README.md
+++ b/suites/README.md
@@ -5,6 +5,7 @@ Different end-to-end test suites for validating the XMTP protocol functionality,
 | Suite                | Purpose                                                    | Link to test file                       |
 | -------------------- | ---------------------------------------------------------- | --------------------------------------- |
 | **TS_Agents**        | Tests the health of the agent ecosystem                    | [TS_Agents](./TS_Agents/)               |
+| **TS_Gm**            | Tests the GM browser and bot                               | [TS_Gm](./TS_Gm/)                       |
 | **TS_Delivery**      | Verifies message delivery reliability                      | [TS_Delivery](./TS_Delivery/)           |
 | **TS_Fork**          | Investigates group conversation forking through membership | [TS_Fork](./TS_Fork/)                   |
 | **TS_Notifications** | Validates push notification functionality                  | [TS_Notifications](./TS_Notifications/) |

--- a/suites/TS_Gm/README.md
+++ b/suites/TS_Gm/README.md
@@ -1,0 +1,72 @@
+# XMTP GM Bot Testing Suite (TS_Gm)
+
+This test suite validates the functionality and responsiveness of the XMTP GM bot in production environments.
+
+## What it does
+
+- Sends test messages to the XMTP GM bot in both DMs and groups
+- Validates that the bot responds with "gm" when sent a message
+- Tests the bot using both direct SDK interactions and UI testing with Playwright
+- Measures response times and success rates
+
+## Setup
+
+```bash
+git clone --depth=1 https://github.com/xmtp/xmtp-qa-testing
+cd xmtp-qa-testing
+yarn install
+```
+
+## Key files
+
+- [TS_Gm.test.ts](./TS_Gm.test.ts) - Test implementation that sends messages and validates GM bot responses
+- [GitHub Actions](https://github.com/xmtp/xmtp-qa-testing/actions/workflows/TS_Gm.yml) - Workflow configuration for running the tests
+
+## Test snippet
+
+```typescript
+// From TS_Gm.test.ts
+it("gm-bot: should check if bot is alive", async () => {
+  try {
+    // Create conversation with the bot
+    convo = await workers.get("bob")!.client.conversations.newDmWithIdentifier({
+      identifierKind: IdentifierKind.Ethereum,
+      identifier: gmBotAddress,
+    });
+
+    expect(convo).toBeDefined();
+    console.log("convo", convo.id);
+    const result = await verifyDmStream(convo!, workers.getWorkers(), "hi");
+    expect(result.allReceived).toBe(true);
+  } catch (e) {
+    logError(e, expect.getState().currentTestName);
+    throw e;
+  }
+});
+```
+
+## Test execution
+
+```bash
+yarn test TS_Gm
+```
+
+## Automation
+
+Tests run automatically via GitHub Actions:
+
+```yaml
+# From TS_Gm.yml
+name: TS_Gm
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "10 * * * *" # Runs at 10 minutes past each hour
+  workflow_dispatch:
+```
+
+## Artifacts
+
+Test logs, screenshots, and results are stored as artifacts in GitHub Actions for diagnostic purposes.

--- a/suites/TS_Gm/TS_Gm.test.ts
+++ b/suites/TS_Gm/TS_Gm.test.ts
@@ -2,7 +2,7 @@ import { loadEnv } from "@helpers/client";
 import generatedInboxes from "@helpers/generated-inboxes.json";
 import { logError } from "@helpers/logger";
 import { XmtpPlaywright } from "@helpers/playwright";
-import { defaultValues, sleep } from "@helpers/tests";
+import { verifyDmStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -18,16 +18,19 @@ describe(testName, () => {
   let convo: Conversation;
   let workers: WorkerManager;
 
-  const xmtpTester = new XmtpPlaywright({ headless: false, env: "production" });
+  const xmtpTester = new XmtpPlaywright({
+    headless: false,
+    env: "production",
+  });
   beforeAll(async () => {
-    await xmtpTester.startPage();
     workers = await getWorkers(
       ["bob"],
       testName,
       typeofStream.Message,
-      typeOfResponse.Gm,
+      typeOfResponse.None,
       "production",
     );
+    console.log("Testing GM bot", gmBotAddress);
   });
   setupTestLifecycle({
     expect,
@@ -43,17 +46,10 @@ describe(testName, () => {
           identifier: gmBotAddress,
         });
 
-      await convo.sync();
-      const messages = await convo.messages();
-      const prevMessageCount = messages.length;
-      console.log("prevMessageCount", prevMessageCount);
-      // Send a simple message
-      const sentMessageId = await convo.send("gm");
-      console.log("sentMessageId", sentMessageId);
-      await sleep(defaultValues.streamTimeout);
-      await convo.sync();
-      const messagesAfter = await convo.messages();
-      expect(messagesAfter.length).toBe(prevMessageCount + 2);
+      expect(convo).toBeDefined();
+      console.log("convo", convo.id);
+      const result = await verifyDmStream(convo!, workers.getWorkers(), "hi");
+      expect(result.allReceived).toBe(true);
     } catch (e) {
       logError(e, expect.getState().currentTestName);
       throw e;
@@ -62,12 +58,13 @@ describe(testName, () => {
 
   it("should respond to a message", async () => {
     try {
+      await xmtpTester.startPage();
       await xmtpTester.newDmFromUI(gmBotAddress);
       await xmtpTester.sendMessage("hi");
       const result = await xmtpTester.waitForResponse(["gm"]);
       expect(result).toBe(true);
     } catch (error) {
-      await xmtpTester.takeSnapshot(gmBotAddress);
+      await xmtpTester.takeSnapshot("gm-dm");
       logError(error, gmBotAddress);
       throw error;
     }
@@ -82,7 +79,7 @@ describe(testName, () => {
       const result = await xmtpTester.waitForResponse(["gm"]);
       expect(result).toBe(true);
     } catch (e) {
-      await xmtpTester.takeSnapshot(gmBotAddress);
+      await xmtpTester.takeSnapshot("gm-group");
       logError(e, expect.getState().currentTestName);
       throw e;
     }


### PR DESCRIPTION
### Improve test automation reliability by refactoring address input handling and adding wait conditions in `XmtpPlaywright` class
* Refactors the `newGroupFromUI` method in [helpers/playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/263/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) to extract address input handling and add wait conditions
* Adds a 1-second timeout wait in the `sendMessage` method to ensure message input loading
* Updates test implementation in [suites/TS_Gm/TS_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/263/files#diff-5bd618685ddc44cad0b8d171e3a6f352b19a9894c11abfd6a1930c4e4f735a56) to use `verifyDmStream` helper and improve test isolation
* Adds documentation for new `TS_Gm` test suite in [suites/TS_Gm/README.md](https://github.com/xmtp/xmtp-qa-testing/pull/263/files#diff-a93e8ca3c6293269b6c4f3b45c571dec2be2fa6e9fafa2885944702afc6527b6) and updates test suite table in [suites/README.md](https://github.com/xmtp/xmtp-qa-testing/pull/263/files#diff-5762ed4d5d7990eaec92cd3b240359fe7e25e1425fd259386f2ba4c2b8eebbb5)

#### 📍Where to Start
Start with the `newGroupFromUI` method refactoring in [helpers/playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/263/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) as it contains the core changes to address input handling.

----

_[Macroscope](https://app.macroscope.com) summarized a44f0f3._