### PR TITLE
Refactor test commands to use max-attempts flag

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests with retry
-        run: yarn cli test ts_agents 1
+        run: yarn cli test ts_agents --max-attempts 1
       - name: Send Slack notification
         if: always()
         env:

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests with retry
-        run: yarn cli test at_gm 1
+        run: yarn cli test at_gm --max-attempts 1
       - name: Send Slack notification
         if: always()
         env:

--- a/suites/README.md
+++ b/suites/README.md
@@ -4,23 +4,23 @@ Different end-to-end test suites for validating the XMTP protocol functionality,
 
 ## Automated test suites
 
-| Suite         | Purpose                                 | Link to test file         |
-| ------------- | --------------------------------------- | ------------------------- |
-| **at_agents** | Tests the health of the agent ecosystem | [at_agents](./at_agents/) |
-| **at_gm**     | Tests the GM browser and bot            | [at_gm](./at_gm/)         |
+| Suite         | Purpose                                 | Link to test file                |
+| ------------- | --------------------------------------- | -------------------------------- |
+| **at_agents** | Tests the health of the agent ecosystem | [at_agents](./automated/agents/) |
+| **at_gm**     | Tests the GM browser and bot            | [at_gm](./automated/gm/)         |
 
 ## Manual test suites
 
-| Suite                | Purpose                                                    | Link to test file                       |
-| -------------------- | ---------------------------------------------------------- | --------------------------------------- |
-| **TS_Fork**          | Investigates group conversation forking through membership | [TS_Fork](./TS_Fork/)                   |
-| **TS_Notifications** | Validates push notification functionality                  | [TS_Notifications](./TS_Notifications/) |
-| **TS_Stress**        | Tests system performance under high load conditions        | [TS_Stress](./TS_Stress/)               |
+| Suite                | Purpose                                                    | Link to test file                           |
+| -------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+| **ts_fork**          | Investigates group conversation forking through membership | [ts_fork](./manual/fork/)                   |
+| **ts_notifications** | Validates push notification functionality                  | [ts_notifications](./manual/notifications/) |
+| **ts_stress**        | Tests system performance under high load conditions        | [ts_stress](./manual/stress/)               |
 
 ## Metrics test suites
 
-| Suite           | Purpose                                      | Link to test file                       |
-| --------------- | -------------------------------------------- | --------------------------------------- |
-| **Delivery**    | Verifies message delivery reliability        | [M_delivery](./metrics/delivery/)       |
-| **Performance** | Measures independent operational performance | [M_performance](./metrics/performance/) |
-| **Large**       | Tests performance of group operations        | [M_large](./metrics/large/)             |
+| Suite             | Purpose                                      | Link to test file                       |
+| ----------------- | -------------------------------------------- | --------------------------------------- |
+| **m_delivery**    | Verifies message delivery reliability        | [m_delivery](./metrics/delivery/)       |
+| **m_performance** | Measures independent operational performance | [m_performance](./metrics/performance/) |
+| **m_large**       | Tests performance of group operations        | [m_large](./metrics/large/)             |


### PR DESCRIPTION
### Update test commands to use `--max-attempts` flag instead of positional arguments for retry configuration
* Modifies test execution commands in [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/282/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and [Gm.yml](https://github.com/xmtp/xmtp-qa-testing/pull/282/files#diff-05b80ad4b81eb8fa2bbe3e649e10be6a5dc0a803fc447955c33ba73a99dc14b9) to use `--max-attempts` named parameter instead of positional argument for specifying test retry attempts
* Updates test suite directory paths and naming conventions in [README.md](https://github.com/xmtp/xmtp-qa-testing/pull/282/files#diff-5762ed4d5d7990eaec92cd3b240359fe7e25e1425fd259386f2ba4c2b8eebbb5), organizing automated tests under `automated/` directory, manual tests under `manual/` directory, and standardizing lowercase naming with appropriate prefixes (`at_`, `ts_`, `m_`)

#### 📍Where to Start
Begin by reviewing the workflow changes in [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/282/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and [Gm.yml](https://github.com/xmtp/xmtp-qa-testing/pull/282/files#diff-05b80ad4b81eb8fa2bbe3e649e10be6a5dc0a803fc447955c33ba73a99dc14b9) which modify the test execution commands.

----

_[Macroscope](https://app.macroscope.com) summarized 5ecc28d._