### PR TITLE
Fix test command in workflow for correct agent name

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests with retry
-        run: yarn retry ts_agents --max-attempts 1
+        run: yarn retry at_agents --max-attempts 1
       - name: Send Slack notification
         if: always()
         env:

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -25,6 +25,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
### Update test command parameter from `ts_agents` to `at_agents` in GitHub Actions workflow to execute correct agent test suite
The `yarn retry` command parameter in the 'Run tests with retry' step within [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/285/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) has been modified to use `at_agents` instead of `ts_agents` while maintaining the `--max-attempts 1` setting.

#### 📍Where to Start
Start by reviewing the test command modification in the 'Run tests with retry' step within [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/285/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91).

----

_[Macroscope](https://app.macroscope.com) summarized 8333995._