### PR TITLE
Fix gen:keys path

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cli": "tsx scripts/run-cli.ts",
     "format": "prettier -w .",
     "functional": "npx vitest run ./functional/*.test.ts --pool=forks --fileParallelism=false",
-    "gen:keys": "tsx scripts/generate-keys.ts",
+    "gen:keys": "tsx scripts/gen.ts",
     "large": "npx vitest run ./suites/metrics/Large/*.test.ts --pool=forks --fileParallelism=false",
     "lint": "eslint .",
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",

--- a/scripts/run-cli.ts
+++ b/scripts/run-cli.ts
@@ -12,7 +12,7 @@ function showUsageAndExit() {
     "  bot <bot_name> [bot_args...]        - Runs a bot (e.g., gm-bot)",
   );
   console.error(
-    "  script <script_name> [script_args...] - Runs a script (e.g., generate-keys)",
+    "  script <script_name> [script_args...] - Runs a script (e.g., gen)",
   );
   console.error(
     "  retry [suite_name_or_path] [options...] - Runs tests (e.g., functional)",
@@ -31,7 +31,7 @@ function showUsageAndExit() {
   console.error("Examples:");
   console.error("  yarn cli bot gm-bot");
   console.error("  yarn cli bot stress 5");
-  console.error("  yarn cli script generate-keys");
+  console.error("  yarn cli script gen");
   console.error("  yarn retry functional --max-attempts 2");
   console.error("  yarn retry ./suites/automated/Gm/gm.test.ts --watch");
   process.exit(1);


### PR DESCRIPTION
## Summary
- point `gen:keys` script at `scripts/gen.ts`
- update `run-cli` usage text for new script name

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file - running an install might help)*