### PR TITLE
Reduce retention days for installation uploads to 90

### DIFF
--- a/.github/workflows/upload-installations.yml
+++ b/.github/workflows/upload-installations.yml
@@ -53,4 +53,4 @@ jobs:
           if-no-files-found: warn
           overwrite: true
           include-hidden-files: true
-          retention-days: 365
+          retention-days: 90


### PR DESCRIPTION
### Reduce artifact retention period from 365 to 90 days in GitHub workflow for installation uploads
Updates the retention configuration in [upload-installations.yml](https://github.com/xmtp/xmtp-qa-testing/pull/294/files#diff-89477c0252d3e47fa4eb9d7ae988e53a3c83880f360e0a6175e046dafbb44144) to store workflow artifacts for 90 days instead of 365 days.

#### 📍Where to Start
Review the retention configuration changes in [upload-installations.yml](https://github.com/xmtp/xmtp-qa-testing/pull/294/files#diff-89477c0252d3e47fa4eb9d7ae988e53a3c83880f360e0a6175e046dafbb44144)

----

_[Macroscope](https://app.macroscope.com) summarized eb66be6._