### PR TITLE
Add test coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,13 @@ yarn install
 - **Helpers:** Utility functions in the [helpers section](/helpers/)
 - **Scripts:** Automation scripts in the [scripts section](/scripts/)
 - **Loom recording:** [Loom recording](https://www.loom.com/share/f447b9a602e44093bce5412243e53664)
+
+### Test coverage
+
+Generate a coverage report for the entire monorepo:
+
+```bash
+yarn coverage
+```
+
+The report will be saved in the `coverage` directory and summarized in the terminal output.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "retry": "yarn cli retry",
     "script": "yarn cli script",
     "start": "vitest --ui --standalone --watch ",
-    "test": "vitest"
+    "test": "vitest",
+    "coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@xmtp/content-type-reaction": "^2.0.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,11 @@ export default defineConfig({
       host: "0.0.0.0",
       port: 51204,
     },
+    coverage: {
+      provider: "c8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+    },
     // Add this to suppress unhandled errors at the end
     dangerouslyIgnoreUnhandledErrors: true,
   },


### PR DESCRIPTION
## Summary
- add `coverage` script to run tests with coverage
- enable coverage reporting in Vitest config
- document how to generate test coverage

## Testing
- `yarn --version` *(fails: connect EHOSTUNREACH)*