### PR TITLE
Refactor test scripts and remove coverage config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "retry": "yarn cli retry",
     "script": "yarn cli script",
     "start": "vitest --ui --standalone --watch ",
-    "test": "vitest",
-    "coverage": "vitest run --coverage"
+    "test": "vitest"
   },
   "dependencies": {
     "@xmtp/content-type-reaction": "^2.0.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,12 +25,6 @@ export default defineConfig({
       host: "0.0.0.0",
       port: 51204,
     },
-    coverage: {
-      provider: "c8",
-      reporter: ["text", "lcov"],
-      reportsDirectory: "./coverage",
-    },
-    // Add this to suppress unhandled errors at the end
     dangerouslyIgnoreUnhandledErrors: true,
   },
 });


### PR DESCRIPTION
### Remove test coverage configuration and scripts from Vitest setup
* Removed `coverage` script from [package.json](https://github.com/xmtp/xmtp-qa-testing/pull/301/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) that previously executed `vitest run --coverage`
* Added new rate-limited test suite in [rate-limited.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/301/files#diff-cbd6199928c2ce0bd14827a64086c0343fc72f723624912c3d8329ed59390d24)
* Removed coverage configuration section from [vitest.config.ts](https://github.com/xmtp/xmtp-qa-testing/pull/301/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) including c8 provider settings and report output paths

#### 📍Where to Start
Start with the coverage configuration removal in [vitest.config.ts](https://github.com/xmtp/xmtp-qa-testing/pull/301/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) as it contains the core test runner setup changes.

----

_[Macroscope](https://app.macroscope.com) summarized 4e4d387._