### PR TITLE
Update response time threshold to 9 seconds for agents

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -1,5 +1,5 @@
 name: Agents
-description: Check that agents answer response is below 7 seconds for a new user. If it fails notify the team.
+description: Check that agents answer response is below 9 seconds for a new user. If it fails notify the team.
 
 on:
   schedule:
@@ -18,7 +18,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       WALLET_KEY: ${{ secrets.WALLET_KEY }}
-      DEFAULT_STREAM_TIMEOUT_MS: 7000
+      DEFAULT_STREAM_TIMEOUT_MS: 9000
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
     steps:

--- a/functional/README.md
+++ b/functional/README.md
@@ -42,7 +42,7 @@ The `browser.test.ts` module tests XMTP in browser environments.
 
 ```typescript
 // Create a new Playwright instance for browser testing
-const xmtpPlaywright = new XmtpPlaywright(headless, env);
+const xmtpPlaywright = new playwright(headless, env);
 
 // Test group creation and messaging in browser
 await xmtpPlaywright.createGroupAndReceiveGm(addresses);

--- a/functional/browser.test.ts
+++ b/functional/browser.test.ts
@@ -1,6 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { XmtpPlaywright } from "@helpers/playwright";
+import { playwright } from "@helpers/playwright";
 import { getInboxIds } from "@helpers/tests";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -9,7 +9,7 @@ loadEnv(testName);
 
 describe(testName, () => {
   // Check if GM_BOT_ADDRESS environment variable is set
-  const xmtpTester = new XmtpPlaywright({
+  const xmtpTester = new playwright({
     headless: true,
     env: "production",
   });

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -159,7 +159,7 @@ The `playwright.ts` module provides browser automation for testing XMTP in web a
 
 ```typescript
 // Create a new Playwright instance
-const xmtpPlaywright = new XmtpPlaywright(headless, env);
+const xmtpPlaywright = new playwright(headless, env);
 
 // Create a group and check for response
 await xmtpPlaywright.createGroupAndReceiveGm(addresses);

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -14,13 +14,13 @@ export type BrowserSession = {
   page: Page;
 };
 
-interface XmtpPlaywrightOptions {
+interface playwrightOptions {
   headless?: boolean;
   env?: XmtpEnv | null;
   defaultUser?: boolean;
 }
 
-export class XmtpPlaywright {
+export class playwright {
   private browser: Browser | null = null;
   private page: Page | null = null;
   private readonly isHeadless: boolean;
@@ -30,11 +30,7 @@ export class XmtpPlaywright {
   private readonly defaultUser: boolean;
 
   constructor(
-    {
-      headless = true,
-      env = null,
-      defaultUser = false,
-    }: XmtpPlaywrightOptions = {
+    { headless = true, env = null, defaultUser = false }: playwrightOptions = {
       headless: true,
       env: null,
       defaultUser: false,
@@ -46,7 +42,7 @@ export class XmtpPlaywright {
     this.walletKey = process.env.WALLET_KEY as string;
     this.encryptionKey = process.env.ENCRYPTION_KEY as string;
     this.defaultUser = defaultUser;
-    console.debug("Starting XmtpPlaywright with env:", this.env);
+    console.debug("Starting playwright with env:", this.env);
   }
 
   /**

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -14,15 +14,11 @@ export type VerifyStreamResult = {
   allReceived: boolean;
   messageReceivedCount: number;
   receiverCount: number;
-  eventTimings: string;
+  eventTimings: number[];
   averageEventTiming: number;
   stats?: {
     receptionPercentage: number;
     orderPercentage: number;
-    workersInOrder: number;
-    workerCount: number;
-    totalReceivedMessages: number;
-    totalExpectedMessages: number;
   };
 };
 
@@ -228,10 +224,10 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
     allReceived: allReceived.every((msgs) => msgs.length === count),
     receiverCount: allReceived.length,
     messageReceivedCount: unescapedMessages.length,
-    eventTimings: flatEventTimingsList.join(","),
+    eventTimings: flatEventTimingsList, // Use the new flat list
     averageEventTiming,
   };
-  console.log(JSON.stringify(allResults, null, 2));
+  console.log(JSON.stringify(allResults));
   return allResults;
 }
 
@@ -425,6 +421,7 @@ export async function verifyMembershipStream(
       const sent: { inboxId: string; sentAt: number }[] = [];
       const sentAt = Date.now();
       await group.addMembers(membersToAdd);
+      console.debug("member added", membersToAdd);
       sent.push({ inboxId: membersToAdd[0], sentAt });
       return sent;
     },
@@ -585,10 +582,6 @@ export function calculateMessageStats(
   const stats = {
     receptionPercentage,
     orderPercentage,
-    workersInOrder,
-    workerCount,
-    totalReceivedMessages,
-    totalExpectedMessages,
   };
   return stats;
 }

--- a/suites/automated/Gm/at_Gm.test.ts
+++ b/suites/automated/Gm/at_Gm.test.ts
@@ -1,6 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { XmtpPlaywright } from "@helpers/playwright";
+import { playwright } from "@helpers/playwright";
 import { verifyDmStream } from "@helpers/streams";
 import { getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
@@ -16,7 +16,7 @@ const gmBotAddress = process.env.GM_BOT_ADDRESS as string;
 describe(testName, () => {
   let workers: WorkerManager;
 
-  const xmtpTester = new XmtpPlaywright({
+  const xmtpTester = new playwright({
     headless: true,
     env: "production",
   });

--- a/suites/manual/Fork/TS_Fork.test.ts
+++ b/suites/manual/Fork/TS_Fork.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { appendToEnv, getFixedNames } from "@helpers/tests";
+import { appendToEnv, getFixedNames, sleep } from "@helpers/tests";
 import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import { type Client, type Conversation, type Group } from "@xmtp/node-sdk";

--- a/suites/manual/Fork/TS_Fork.test.ts
+++ b/suites/manual/Fork/TS_Fork.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { appendToEnv, getFixedNames, getRandomNames } from "@helpers/tests";
+import { appendToEnv, getFixedNames } from "@helpers/tests";
 import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import { type Client, type Conversation, type Group } from "@xmtp/node-sdk";

--- a/suites/metrics/Delivery/M_Delivery.test.ts
+++ b/suites/metrics/Delivery/M_Delivery.test.ts
@@ -50,11 +50,16 @@ describe(testName, async () => {
         amountofMessages,
         randomSuffix,
       );
-      expect(verifyResult.stats?.receptionPercentage).toBeGreaterThan(95);
-      expect(verifyResult.stats?.orderPercentage).toBeGreaterThan(95);
+      const receptionPercentage = verifyResult.stats?.receptionPercentage;
+      const orderPercentage = verifyResult.stats?.orderPercentage;
+      if (!receptionPercentage || !orderPercentage) {
+        throw new Error("No stats found");
+      }
+      expect(receptionPercentage).toBeGreaterThan(95);
+      expect(orderPercentage).toBeGreaterThan(95);
 
       sendDeliveryMetric(
-        verifyResult.stats?.receptionPercentage ?? 0,
+        receptionPercentage,
         workers.getCreator().sdkVersion,
         workers.getCreator().libXmtpVersion,
         testName,
@@ -62,7 +67,7 @@ describe(testName, async () => {
         "delivery",
       );
       sendDeliveryMetric(
-        verifyResult.stats?.orderPercentage ?? 0,
+        orderPercentage,
         workers.getCreator().sdkVersion,
         workers.getCreator().libXmtpVersion,
         testName,
@@ -108,11 +113,13 @@ describe(testName, async () => {
         randomSuffix,
       );
 
-      expect(stats.receptionPercentage).toBeGreaterThan(95);
-      expect(stats.orderPercentage).toBeGreaterThan(95);
+      const receptionPercentage = stats.receptionPercentage;
+      const orderPercentage = stats.orderPercentage;
+      expect(receptionPercentage).toBeGreaterThan(95);
+      expect(orderPercentage).toBeGreaterThan(95);
 
       sendDeliveryMetric(
-        stats.receptionPercentage,
+        receptionPercentage,
         workers.getCreator().sdkVersion,
         workers.getCreator().libXmtpVersion,
         testName,
@@ -120,7 +127,7 @@ describe(testName, async () => {
         "delivery",
       );
       sendDeliveryMetric(
-        stats.orderPercentage,
+        orderPercentage,
         workers.getCreator().sdkVersion,
         workers.getCreator().libXmtpVersion,
         testName,
@@ -189,12 +196,16 @@ describe(testName, async () => {
         amountofMessages,
         randomSuffix,
       );
-
-      expect(stats.receptionPercentage).toBeGreaterThan(95);
-      expect(stats.orderPercentage).toBeGreaterThan(95);
+      const receptionPercentage = stats.receptionPercentage;
+      const orderPercentage = stats.orderPercentage;
+      if (!receptionPercentage || !orderPercentage) {
+        throw new Error("No stats found");
+      }
+      expect(receptionPercentage).toBeGreaterThan(95);
+      expect(orderPercentage).toBeGreaterThan(95);
 
       sendDeliveryMetric(
-        stats.receptionPercentage,
+        receptionPercentage,
         offlineWorker.sdkVersion,
         offlineWorker.libXmtpVersion,
         testName,
@@ -202,7 +213,7 @@ describe(testName, async () => {
         "delivery",
       );
       sendDeliveryMetric(
-        stats.orderPercentage,
+        orderPercentage,
         offlineWorker.sdkVersion,
         offlineWorker.libXmtpVersion,
         testName,

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -386,6 +386,9 @@ export async function getWorkers(
   );
   await manager.createWorkers(descriptors);
 
+  if (typeofStreamType !== typeofStream.None) {
+    await sleep(4000);
+  }
   manager.printWorkers();
   return manager;
 }


### PR DESCRIPTION
### Increase agent response timeout threshold from 7 to 9 seconds in `.github/workflows/Agents.yml` to allow more response time
* Updates agent response timeout from 7000ms to 9000ms in [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/308/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and related documentation
* Renames `XmtpPlaywright` class to `playwright` across multiple test and helper files
* Modifies `VerifyStreamResult` type in [streams.ts](https://github.com/xmtp/xmtp-qa-testing/pull/308/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to use number arrays for event timings
* Adds 4-second delay after worker creation in [manager.ts](https://github.com/xmtp/xmtp-qa-testing/pull/308/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) `getWorkers` function
* Improves error handling for percentage values in [M_Delivery.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/308/files#diff-3c20b46427512fd21a47af0ef4d5d96fa0ed2dafb2ca8d2755306f23a229f242)

#### 📍Where to Start
Start with the timeout configuration changes in [Agents.yml](https://github.com/xmtp/xmtp-qa-testing/pull/308/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91), which sets the core timeout threshold that affects the entire test suite.

----

_[Macroscope](https://app.macroscope.com) summarized 9c14430._