### PR TITLE
Add pull request trigger and fix test expectations

### DIFF
--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -2,6 +2,9 @@ name: Gm
 description: "should verify performance of the library in the dev network"
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "15,45 * * * *" # Runs at 15 and 45 minutes past each hour
   workflow_dispatch:

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -40,7 +40,11 @@ jobs:
         run: yarn
       - name: Run tests with retry
         run: yarn retry at_gm
-
+      - name: Send Slack notification
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: npx tsx helpers/slack.ts
       - name: Upload reports artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -21,6 +21,7 @@ jobs:
       LOGGING_LEVEL: ${{ vars.LOGGING_LEVEL }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
+      DEFAULT_STREAM_TIMEOUT_MS: 9000
       GM_BOT_ADDRESS: ${{ vars.GM_BOT_ADDRESS }}
       WALLET_KEY: ${{ secrets.WALLET_KEY }}
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}

--- a/functional/groups.test.ts
+++ b/functional/groups.test.ts
@@ -55,7 +55,7 @@ describe(testName, async () => {
       try {
         await groupsBySize[i].sync();
         const members = await groupsBySize[i].members();
-        expect(members.length).toBe(i);
+        expect(members.length).toBe(i + 1);
       } catch (e: unknown) {
         logError(e, expect.getState().currentTestName);
         throw e;

--- a/helpers/playwright.ts
+++ b/helpers/playwright.ts
@@ -128,7 +128,7 @@ export class playwright {
   public async waitForResponse(expectedMessage: string[]): Promise<boolean> {
     if (!this.page) throw new Error("Page is not initialized");
     for (let i = 0; i < 6; i++) {
-      await this.page.waitForTimeout(defaultValues.streamTimeout);
+      await this.page.waitForTimeout(1000);
       const responseText = await this.getLatestMessageText();
       if (
         expectedMessage.some((phrase) =>

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -572,7 +572,7 @@ export const defaultNames = [
 export const defaultValues = {
   amount: 5, // 5 messages
   playwrightBeforeSendTimeout: 1000, // 1 second
-  streamTimeout: 7000, // 3 seconds
+  streamTimeout: 3000, // 3 seconds
   timeout: 40000, // 40 seconds
   perMessageTimeout: 3000, // 3 seconds
   defaultNames,

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -572,7 +572,7 @@ export const defaultNames = [
 export const defaultValues = {
   amount: 5, // 5 messages
   playwrightBeforeSendTimeout: 1000, // 1 second
-  streamTimeout: 3000, // 3 seconds
+  streamTimeout: 7000, // 3 seconds
   timeout: 40000, // 40 seconds
   perMessageTimeout: 3000, // 3 seconds
   defaultNames,

--- a/suites/automated/Gm/at_Gm.test.ts
+++ b/suites/automated/Gm/at_Gm.test.ts
@@ -2,7 +2,7 @@ import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { playwright } from "@helpers/playwright";
 import { verifyDmStream } from "@helpers/streams";
-import { getInboxIds } from "@helpers/tests";
+import { getAddresses, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeOfResponse, typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -17,7 +17,7 @@ describe(testName, () => {
   let workers: WorkerManager;
 
   const xmtpTester = new playwright({
-    headless: true,
+    headless: false,
     env: "production",
   });
   beforeAll(async () => {
@@ -63,7 +63,7 @@ describe(testName, () => {
   });
   it("should create a group and send a message", async () => {
     try {
-      await xmtpTester.newGroupFromUI([...getInboxIds(4), gmBotAddress]);
+      await xmtpTester.newGroupFromUI([...getAddresses(4), gmBotAddress]);
       await xmtpTester.sendMessage("hi");
       const result = await xmtpTester.waitForResponse(["gm"]);
       expect(result).toBe(true);

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -362,6 +362,9 @@ export class WorkerClient extends Worker {
               message.contentType?.typeId === "text" &&
               type === typeofStream.Message
             ) {
+              console.debug(
+                `[${this.nameId}] Received message, ${message.content as string}`,
+              );
               // Handle auto-responses if enabled
               if (this.shouldRespondToMessage(message)) {
                 await this.handleResponse(message);


### PR DESCRIPTION
### Configure GitHub workflow to run on pull requests and update test timeouts and expectations
* Updates [Gm.yml](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-05b80ad4b81eb8fa2bbe3e649e10be6a5dc0a803fc447955c33ba73a99dc14b9) to trigger on pull requests to main branch and sets `DEFAULT_STREAM_TIMEOUT_MS` to 9000ms
* Refactors [streams.ts](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) `verifyDmStream` function with simplified DM conversation creation and adds `receiverCount` property
* Modifies [playwright.ts](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-c01d71ab02aba393bcfd69faec4bf9e5f4a7c80bf3c865c57f25e47866fb821e) `waitForResponse` timeout to 1000ms
* Updates [at_Gm.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-e5f0af6b065b8326fbbc0ec846f96b695d0b377540a491c97f8b4ec3514a727b) to use visible browser mode and `getAddresses` for participant selection
* Adjusts [groups.test.ts](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-f490ad9961b7334f25051e47c933fb520fd4038981d79a6fcba6466413433ad3) `syncGroup` test expectations for member count
* Adds message logging in [main.ts](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) `WorkerClient` class

#### 📍Where to Start
Start with the workflow configuration changes in [Gm.yml](https://github.com/xmtp/xmtp-qa-testing/pull/311/files#diff-05b80ad4b81eb8fa2bbe3e649e10be6a5dc0a803fc447955c33ba73a99dc14b9) as it defines the new pull request trigger and environment variable that affects the test execution environment.

----

_[Macroscope](https://app.macroscope.com) summarized 013cc04._